### PR TITLE
[🔀 BE] 소셜 로그인 정보 엔티티 생성

### DIFF
--- a/src/main/java/com/mini/buting/api/member/domain/MemberSocial.java
+++ b/src/main/java/com/mini/buting/api/member/domain/MemberSocial.java
@@ -44,7 +44,7 @@ public class MemberSocial extends BaseTimeEntity {
     @Comment("소셜 계정 이메일")
     private String email;
 
-    public static MemberSocial toMemberSocial(Member member, SocialProvider providerName, String providerId, String email) {
+    public static MemberSocial create(Member member, SocialProvider providerName, String providerId, String email) {
         return MemberSocial.builder()
                 .member(member)
                 .providerName(providerName)

--- a/src/main/java/com/mini/buting/api/member/domain/MemberSocial.java
+++ b/src/main/java/com/mini/buting/api/member/domain/MemberSocial.java
@@ -1,0 +1,55 @@
+package com.mini.buting.api.member.domain;
+
+import com.mini.buting.global.common.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.Comment;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "member_social", indexes = {
+        @Index(name = "idx_member_social_provider_id", columnList = "provider_id"),
+        @Index(name = "idx_member_social_member", columnList = "member_id")
+}, uniqueConstraints = {
+        @UniqueConstraint(name = "uk_member_social_email", columnNames = {"email"}),
+        // 특정 소셜 플랫폼 내에서의 고유 식별값 중복 방지
+        @UniqueConstraint(name = "uk_member_social_provider_combination", columnNames = {"provider_name", "provider_id"})
+})
+@Comment("멤버 소셜 연동 정보 테이블")
+public class MemberSocial extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Comment("소셜 로그인 식별자")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false, foreignKey = @ForeignKey(name = "FK_member_social_member"))
+    @Comment("멤버 ID")
+    private Member member;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "provider_name", nullable = false, length = 20)
+    @Comment("소셜 로그인 제공자 (KAKAO 등)")
+    private SocialProvider providerName;
+
+    @Column(name = "provider_id", nullable = false, length = 100)
+    @Comment("소셜 플랫폼 제공 고유 식별값")
+    private String providerId;
+
+    @Column(name = "email", length = 100)
+    @Comment("소셜 계정 이메일")
+    private String email;
+
+    public static MemberSocial toMemberSocial(Member member, SocialProvider providerName, String providerId, String email) {
+        return MemberSocial.builder()
+                .member(member)
+                .providerName(providerName)
+                .providerId(providerId)
+                .email(email)
+                .build();
+    }
+}

--- a/src/main/java/com/mini/buting/api/member/domain/SocialProvider.java
+++ b/src/main/java/com/mini/buting/api/member/domain/SocialProvider.java
@@ -1,0 +1,32 @@
+package com.mini.buting.api.member.domain;
+
+import com.mini.buting.global.exception.BaseException;
+import com.mini.buting.global.response.BaseResponseStatus;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.util.StringUtils;
+
+import java.util.Collections;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+@Getter
+@AllArgsConstructor
+public enum SocialProvider {
+    KAKAO("kakao");
+
+    private static final Map<String, SocialProvider> PROVIDER_NAME_MAP = Collections.unmodifiableMap(Stream.of(values())
+            .collect(Collectors.toMap(SocialProvider::name, Function.identity())));
+
+    private final String name;
+
+    public static SocialProvider toProviderName(String providerName) {
+        SocialProvider provider = (!StringUtils.hasText(providerName)) ? null : PROVIDER_NAME_MAP.get(providerName.toUpperCase(Locale.ROOT));
+        return Optional.ofNullable(provider)
+                .orElseThrow(() -> new BaseException(BaseResponseStatus.SOCIAL_TYPE_NOT_SUPPORTED));
+    }
+}

--- a/src/main/java/com/mini/buting/global/response/BaseResponseStatus.java
+++ b/src/main/java/com/mini/buting/global/response/BaseResponseStatus.java
@@ -36,7 +36,8 @@ public enum BaseResponseStatus {
     /**
      * 2000: Member Service 관련 에러
      */
-    MEMBER_ALREADY_DELETED(HttpStatus.BAD_REQUEST, false, 2001, "이미 탈퇴 처리된 회원입니다.");
+    MEMBER_ALREADY_DELETED(HttpStatus.BAD_REQUEST, false, 2001, "이미 탈퇴 처리된 회원입니다."),
+    SOCIAL_TYPE_NOT_SUPPORTED(HttpStatus.BAD_REQUEST, false, 2002, "지원하지 않는 소셜 로그인 유형입니다.");
 
     private final HttpStatusCode httpStatusCode;
     private final boolean isSuccess;


### PR DESCRIPTION
<!--
🔀 Develop PR (제목을 입력해주세요)

📌 사용 예시:
[🔀 FE] 로그인 페이지 UI 수정
[🔀 BE] 사용자 인증 로직 리팩토링

⚠️ (괄호) 항목은 모두 지우고 알맞게 작성해주세요.
-->

### 🔗 Connected Issue

Closes miniPJT-BuTing/backend_spring#12

### 📅 Development Period

<!-- 작업 기간을 YYYY.MM.DD ~ YYYY.MM.DD 형식으로 입력해주세요 -->

2025.01.03 ~ 2025.01.03

### 📢 Description

<!-- 작업 내용을 명확하게 설명해주세요 -->
#### 1. `member_social` 테이블 생성
- **주의할 점:** 설계와 달리, `MemberSocial`의 `email`필드를 **nullable로 등록함**
  - 사유: Kakao와 같이 사용자가 이메일 제공에 동의하지 않으면 이메일 없이 정보가 올 수 있는 소셜 제공자가 있어서 nullable로 두었음. 이후에 이메일 제공 여부에 따라 추가 이메일 필드를 받는 등 비즈니스 로직이 필요할 수도 있음.
- `provider_name`, `provider_id` 필드에 **복합 유니크 제약 조건**을 걸어 플랫폼이 달라도 고유 식별값이 겹칠 가능성을 대비함

#### 2. 소셜 인증 제공자 `SocialProvider` enum 생성 (설계 상 Kakao 만 등록함)
#### 3. 미지원 소셜 인증에 대한 Exception 응답 정의
```java
SOCIAL_TYPE_NOT_SUPPORTED(HttpStatus.BAD_REQUEST, false, 2002, "지원하지 않는 소셜 로그인 유형입니다.");
```

### ✔️ PR Checklist

MR이 아래 사항을 충족하는지 확인해주세요:

- [x] Merge 방향 및 Branch 확인했습니다.
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 코드가 정상적으로 동작하는지 테스트했습니다.
- [x] 해당하는 이슈번호를 올바르게 입력했습니다.

### 🔖 Note

<!-- 참고사항을 적어주세요 -->
#11 병합 전 이 PR을 먼저 병합해주세요.