### PR TITLE
[🚑️ BE] `member` 테이블 <-> `university_domain` 테이블 연관관계 오류 수정

### DIFF
--- a/src/main/java/com/mini/buting/api/member/domain/Member.java
+++ b/src/main/java/com/mini/buting/api/member/domain/Member.java
@@ -3,6 +3,7 @@ package com.mini.buting.api.member.domain;
 import com.mini.buting.api.analysis.domain.FaceShape;
 import com.mini.buting.api.university.domain.Major;
 import com.mini.buting.api.university.domain.University;
+import com.mini.buting.api.university.domain.UniversityDomain;
 import com.mini.buting.global.common.BaseTimeEntity;
 import com.mini.buting.global.exception.BaseException;
 import com.mini.buting.global.response.BaseResponseStatus;
@@ -10,6 +11,7 @@ import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.Comment;
 import org.hibernate.annotations.DynamicUpdate;
+import org.springframework.util.StringUtils;
 
 import java.time.LocalDateTime;
 
@@ -17,12 +19,13 @@ import java.time.LocalDateTime;
 @Table(name = "member", indexes = {
         @Index(name = "idx_member_uuid", columnList = "uuid"),
         @Index(name = "idx_member_nickname", columnList = "nickname"),
-        @Index(name = "idx_member_university", columnList = "university_id"),
+        @Index(name = "idx_member_university_domain", columnList = "university_domain_id"),
         @Index(name = "idx_member_major", columnList = "major_id"),
         @Index(name = "idx_member_face_shape", columnList = "face_shape_id")
 }, uniqueConstraints = {
         @UniqueConstraint(name = "uk_member_uuid", columnNames = {"uuid"}),
-        @UniqueConstraint(name = "uk_member_nickname", columnNames = {"nickname"})
+        @UniqueConstraint(name = "uk_member_nickname", columnNames = {"nickname"}),
+        @UniqueConstraint(name = "uk_university_email", columnNames = {"university_domain_id", "university_email"})
 })
 @Getter
 @Builder
@@ -73,9 +76,13 @@ public class Member extends BaseTimeEntity {
     private String bio;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "university_id", foreignKey = @ForeignKey(name = "FK_member_university"))
-    @Comment("소속 대학 ID")
-    private University university;
+    @JoinColumn(name = "university_domain_id", nullable = false, foreignKey = @ForeignKey(name = "FK_member_university_domain"))
+    @Comment("소속 대학 도메인 ID")
+    private UniversityDomain universityDomain;
+
+    @Column(name = "university_email", nullable = false, length = 100)
+    @Comment("대학 이메일 계정 아이디 (@ 기호 앞부분)")
+    private String universityEmail;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "major_id", foreignKey = @ForeignKey(name = "FK_member_major"))
@@ -103,5 +110,16 @@ public class Member extends BaseTimeEntity {
         }
         this.isDeleted = true;
         this.deletedAt = LocalDateTime.now();
+    }
+
+    public University getUniversity() {
+        return this.universityDomain != null ? this.universityDomain.getUniversity() : null;
+    }
+
+    public String getFullUniversityEmail() {
+        if (this.universityDomain == null || !StringUtils.hasText(this.universityEmail)) {
+            return null;
+        }
+        return this.universityEmail + "@" + this.universityDomain.getDomain();
     }
 }


### PR DESCRIPTION
<!--
🚑️ Hotfix MR (제목을 입력해주세요)

📌 사용 예시:
[🚑️ BE] 배포 후 500 오류 수정
[🚑️ FE] 회원가입 시 닉네임 중복 체크 오류 해결

⚠️ (괄호) 항목은 모두 지우고 알맞게 작성해주세요.
-->

### 🔗 Connected Issue

Closes miniPJT-BuTing/backend_spring#19

### 📅 Development Period

<!-- 작업 기간을 YYYY.MM.DD ~ YYYY.MM.DD 형식으로 입력해주세요 -->

2025.01.03 ~ 2025.01.03

### 📢 Description

#### 1. `university_email` 필드 추가
- erd 설계에도 누락된 사항. 중복된 학교 이메일로 인증 방지를 위해선 인증에 사용되는 email 값을 저장해두어야 하는데 관련 필드가 누락되어 추가했습니다.
- `university_email` 필드에는 학교 인증 이메일의 @ 앞 부분 아이디가 들어가게 됨.
- `university_domain_id`와 복합 유니크 제약 조건을 걸었음.
- 전체 이메일 주소를 생성하는 `getFullUniversityEmail()` 편의 메서드 추가.

#### 2. 잘못된 외래키 (`university`->`university_domain`)
- `University` 엔티티가 아닌 `UniversityDomain` 엔티티를 참조해야 하는 오류 수정
- `UniversityDomain`으로 `University`를 쉽게 조회하는 편의 메서드 추가(`getUniversity()`)

<!-- 작업 내용을 명확하게 설명해주세요 -->

### ✔️ PR Checklist

MR이 아래 사항을 충족하는지 확인해주세요:

- [x] Merge 방향 (hotfix → release, hotfix → develop) 확인했습니다.
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 코드가 정상적으로 동작하는지 테스트했습니다.
- [x] 해당하는 이슈번호를 올바르게 입력했습니다.
