### PR TITLE
Feature/be/team2

### DIFF
--- a/src/main/java/com/mini/buting/api/chat/service/ChatRoomService.java
+++ b/src/main/java/com/mini/buting/api/chat/service/ChatRoomService.java
@@ -15,6 +15,7 @@ import com.mini.buting.api.chat.repository.ChatRoomMemberRepository;
 import com.mini.buting.api.chat.repository.ChatRoomRepository;
 import com.mini.buting.api.matchRequest.domain.MatchRequest;
 import com.mini.buting.api.member.domain.Member;
+import com.mini.buting.api.team.domain.Gender;
 import com.mini.buting.api.team.domain.Team;
 import com.mini.buting.global.exception.BaseException;
 import com.mini.buting.global.response.BaseResponseStatus;
@@ -50,7 +51,7 @@ public class ChatRoomService {
         Team femaleTeam;
 
         Team requestTeam = match.getRequestTeam();
-        if(requestTeam.getGender() == Team.Gender.MALE){
+        if(requestTeam.getGender() == Gender.MALE){
             maleTeam = requestTeam;
             femaleTeam = match.getTargetTeam();
         }

--- a/src/main/java/com/mini/buting/api/friend/domain/Friend.java
+++ b/src/main/java/com/mini/buting/api/friend/domain/Friend.java
@@ -15,7 +15,6 @@ import lombok.NoArgsConstructor;
                 indexes = {
                                 @Index(name = "idx_friend_member1", columnList = "member1_id"),
                                 @Index(name = "idx_friend_member2", columnList = "member2_id"),
-                                @Index(name = "idx_friend_became_friends_at", columnList = "became_friends_at")
                 },
                 uniqueConstraints = {
                                 @UniqueConstraint(name = "uk_friend_pair", columnNames = {"member1_id", "member2_id"})

--- a/src/main/java/com/mini/buting/api/friend/repository/FriendRepository.java
+++ b/src/main/java/com/mini/buting/api/friend/repository/FriendRepository.java
@@ -67,4 +67,36 @@ public interface FriendRepository extends JpaRepository<Friend, Long> {
     Page<Friend> searchFriendsByNickname(@Param("memberId") Long memberId, 
                                         @Param("nickname") String nickname, 
                                         Pageable pageable);
+
+    /**
+     * 특정 멤버의 모든 친구들 조회
+     */
+    @Query("SELECT f FROM Friend f " +
+                    "JOIN FETCH f.member1 m1 " +
+                    "JOIN FETCH f.member2 m2 " +
+                    "JOIN FETCH m1.universityDomain " +
+                    "JOIN FETCH m2.universityDomain " +
+                    "LEFT JOIN FETCH m1.college " +
+                    "LEFT JOIN FETCH m2.college " +
+                    "WHERE f.member1 = :member OR f.member2 = :member")
+    List<Friend> findFriendsByMember(@Param("member") Member member);
+
+    /**
+     * 특정 멤버의 친구들을 검색 (닉네임 또는 이메일로)
+     */
+    @Query("SELECT f FROM Friend f " +
+                    "JOIN FETCH f.member1 m1 " +
+                    "JOIN FETCH f.member2 m2 " +
+                    "JOIN FETCH m1.universityDomain ud1 " +
+                    "JOIN FETCH m2.universityDomain ud2 " +
+                    "LEFT JOIN FETCH m1.college " +
+                    "LEFT JOIN FETCH m2.college " +
+                    "WHERE (f.member1 = :member AND " +
+                    "       (LOWER(m2.nickname) LIKE LOWER(CONCAT('%', :keyword, '%')) OR " +
+                    "        LOWER(CONCAT(m2.universityEmail, '@', ud2.domain)) LIKE LOWER(CONCAT('%', :keyword, '%')))) " +
+                    "OR (f.member2 = :member AND " +
+                    "    (LOWER(m1.nickname) LIKE LOWER(CONCAT('%', :keyword, '%')) OR " +
+                    "     LOWER(CONCAT(m1.universityEmail, '@', ud1.domain)) LIKE LOWER(CONCAT('%', :keyword, '%'))))")
+    List<Friend> findFriendsByMemberAndKeyword(@Param("member") Member member,
+                    @Param("keyword") String keyword);
 }

--- a/src/main/java/com/mini/buting/api/team/controller/TeamController.java
+++ b/src/main/java/com/mini/buting/api/team/controller/TeamController.java
@@ -1,0 +1,95 @@
+package com.mini.buting.api.team.controller;
+
+import com.mini.buting.api.team.dto.request.TeamRequestDto;
+import com.mini.buting.api.team.dto.response.TeamResponseDto;
+import com.mini.buting.api.team.service.TeamInvitationService;
+import com.mini.buting.api.team.service.TeamService;
+import com.mini.buting.global.response.BaseResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/teams")
+@RequiredArgsConstructor
+@Slf4j
+@Tag(name = "Team", description = "팀 관련 API")
+public class TeamController {
+
+    private final TeamService teamService;
+    private final TeamInvitationService teamInvitationService;
+
+    @Operation(summary = "팀 생성", description = "새로운 팀을 생성하고 멤버들을 초대합니다.")
+    @PostMapping
+    public ResponseEntity<BaseResponse<TeamResponseDto.CreateTeamResponse>> createTeam(
+            @Parameter(description = "팀장 ID", required = true)
+            @RequestHeader("X-User-Id") Long leaderId,
+            @Valid @RequestBody TeamRequestDto.CreateTeamRequest request) {
+
+        log.info("팀 생성 API 호출 - leaderId: {}", leaderId);
+
+        TeamResponseDto.CreateTeamResponse response = teamService.createTeam(leaderId, request);
+        
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(BaseResponse.onSuccess(response));
+    }
+
+    @Operation(summary = "친구 검색", description = "팀 초대를 위해 친구를 검색합니다.")
+    @GetMapping("/friends/search")
+    public ResponseEntity<BaseResponse<TeamResponseDto.SearchFriendsResponse>> searchFriends(
+            @Parameter(description = "사용자 ID", required = true)
+            @RequestHeader("X-User-Id") Long memberId,
+            @Parameter(description = "검색 키워드 (닉네임 또는 이메일)")
+            @RequestParam(required = false) String keyword) {
+
+        log.info("친구 검색 API 호출 - memberId: {}, keyword: {}", memberId, keyword);
+
+        TeamRequestDto.SearchFriendsRequest request = TeamRequestDto.SearchFriendsRequest.builder()
+                .keyword(keyword)
+                .build();
+
+        TeamResponseDto.SearchFriendsResponse response = teamService.searchFriends(memberId, request);
+        
+        return ResponseEntity.ok(BaseResponse.onSuccess(response));
+    }
+
+    @Operation(summary = "받은 초대 목록", description = "사용자가 받은 팀 초대 목록을 조회합니다.")
+    @GetMapping("/invitations/received")
+    public ResponseEntity<BaseResponse<List<TeamResponseDto.TeamInvitationDetailResponse>>> getReceivedInvitations(
+            @Parameter(description = "사용자 ID", required = true)
+            @RequestHeader("X-User-Id") Long memberId) {
+
+        log.info("받은 초대 목록 API 호출 - memberId: {}", memberId);
+
+        List<TeamResponseDto.TeamInvitationDetailResponse> response = 
+                teamInvitationService.getReceivedInvitations(memberId);
+        
+        return ResponseEntity.ok(BaseResponse.onSuccess(response));
+    }
+
+    @Operation(summary = "초대 응답", description = "팀 초대를 수락하거나 거절합니다.")
+    @PatchMapping("/invitations/{invitationId}/respond")
+    public ResponseEntity<BaseResponse<TeamResponseDto.RespondToInvitationResponse>> respondToInvitation(
+            @Parameter(description = "사용자 ID", required = true)
+            @RequestHeader("X-User-Id") Long memberId,
+            @Parameter(description = "초대 ID", required = true)
+            @PathVariable Long invitationId,
+            @Valid @RequestBody TeamRequestDto.RespondToInvitationRequest request) {
+
+        log.info("초대 응답 API 호출 - memberId: {}, invitationId: {}, accept: {}", 
+                memberId, invitationId, request.accept());
+
+        TeamResponseDto.RespondToInvitationResponse response = 
+                teamInvitationService.respondToInvitation(memberId, invitationId, request);
+        
+        return ResponseEntity.ok(BaseResponse.onSuccess(response));
+    }
+}

--- a/src/main/java/com/mini/buting/api/team/controller/TeamController.java
+++ b/src/main/java/com/mini/buting/api/team/controller/TeamController.java
@@ -18,7 +18,7 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 
 @RestController
-@RequestMapping("/api/v1/teams")
+@RequestMapping("/v1/teams")
 @RequiredArgsConstructor
 @Slf4j
 @Tag(name = "Team", description = "팀 관련 API")

--- a/src/main/java/com/mini/buting/api/team/controller/TeamController.java
+++ b/src/main/java/com/mini/buting/api/team/controller/TeamController.java
@@ -30,66 +30,63 @@ public class TeamController {
     @Operation(summary = "팀 생성", description = "새로운 팀을 생성하고 멤버들을 초대합니다.")
     @PostMapping
     public ResponseEntity<BaseResponse<TeamResponseDto.CreateTeamResponse>> createTeam(
-            @Parameter(description = "팀장 ID", required = true)
-            @RequestHeader("X-User-Id") Long leaderId,
-            @Valid @RequestBody TeamRequestDto.CreateTeamRequest request) {
+                    @Parameter(description = "팀장 ID", required = true) @RequestHeader("X-User-Id")
+                    Long leaderId, @Valid @RequestBody TeamRequestDto.CreateTeamRequest request) {
 
         log.info("팀 생성 API 호출 - leaderId: {}", leaderId);
 
         TeamResponseDto.CreateTeamResponse response = teamService.createTeam(leaderId, request);
-        
-        return ResponseEntity.status(HttpStatus.CREATED)
-                .body(BaseResponse.onSuccess(response));
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(BaseResponse.onSuccess(response));
     }
 
     @Operation(summary = "친구 검색", description = "팀 초대를 위해 친구를 검색합니다.")
     @GetMapping("/friends/search")
     public ResponseEntity<BaseResponse<TeamResponseDto.SearchFriendsResponse>> searchFriends(
-            @Parameter(description = "사용자 ID", required = true)
-            @RequestHeader("X-User-Id") Long memberId,
-            @Parameter(description = "검색 키워드 (닉네임 또는 이메일)")
-            @RequestParam(required = false) String keyword) {
+                    @Parameter(description = "사용자 ID", required = true) @RequestHeader("X-User-Id")
+                    Long memberId,
+                    @Parameter(description = "검색 키워드 (닉네임 또는 이메일)") @RequestParam(required = false)
+                    String keyword) {
 
         log.info("친구 검색 API 호출 - memberId: {}, keyword: {}", memberId, keyword);
 
-        TeamRequestDto.SearchFriendsRequest request = TeamRequestDto.SearchFriendsRequest.builder()
-                .keyword(keyword)
-                .build();
+        TeamRequestDto.SearchFriendsRequest request =
+                        TeamRequestDto.SearchFriendsRequest.builder().keyword(keyword).build();
 
-        TeamResponseDto.SearchFriendsResponse response = teamService.searchFriends(memberId, request);
-        
+        TeamResponseDto.SearchFriendsResponse response =
+                        teamService.searchFriends(memberId, request);
+
         return ResponseEntity.ok(BaseResponse.onSuccess(response));
     }
 
     @Operation(summary = "받은 초대 목록", description = "사용자가 받은 팀 초대 목록을 조회합니다.")
     @GetMapping("/invitations/received")
     public ResponseEntity<BaseResponse<List<TeamResponseDto.TeamInvitationDetailResponse>>> getReceivedInvitations(
-            @Parameter(description = "사용자 ID", required = true)
-            @RequestHeader("X-User-Id") Long memberId) {
+                    @Parameter(description = "사용자 ID", required = true) @RequestHeader("X-User-Id")
+                    Long memberId) {
 
         log.info("받은 초대 목록 API 호출 - memberId: {}", memberId);
 
-        List<TeamResponseDto.TeamInvitationDetailResponse> response = 
-                teamInvitationService.getReceivedInvitations(memberId);
-        
+        List<TeamResponseDto.TeamInvitationDetailResponse> response =
+                        teamInvitationService.getReceivedInvitations(memberId);
+
         return ResponseEntity.ok(BaseResponse.onSuccess(response));
     }
 
     @Operation(summary = "초대 응답", description = "팀 초대를 수락하거나 거절합니다.")
     @PatchMapping("/invitations/{invitationId}/respond")
     public ResponseEntity<BaseResponse<TeamResponseDto.RespondToInvitationResponse>> respondToInvitation(
-            @Parameter(description = "사용자 ID", required = true)
-            @RequestHeader("X-User-Id") Long memberId,
-            @Parameter(description = "초대 ID", required = true)
-            @PathVariable Long invitationId,
-            @Valid @RequestBody TeamRequestDto.RespondToInvitationRequest request) {
+                    @Parameter(description = "사용자 ID", required = true) @RequestHeader("X-User-Id")
+                    Long memberId, @Parameter(description = "초대 ID", required = true) @PathVariable
+                    Long invitationId,
+                    @Valid @RequestBody TeamRequestDto.RespondToInvitationRequest request) {
 
-        log.info("초대 응답 API 호출 - memberId: {}, invitationId: {}, accept: {}", 
-                memberId, invitationId, request.accept());
+        log.info("초대 응답 API 호출 - memberId: {}, invitationId: {}, accept: {}", memberId,
+                        invitationId, request.accept());
 
-        TeamResponseDto.RespondToInvitationResponse response = 
-                teamInvitationService.respondToInvitation(memberId, invitationId, request);
-        
+        TeamResponseDto.RespondToInvitationResponse response =
+                        teamInvitationService.respondToInvitation(memberId, invitationId, request);
+
         return ResponseEntity.ok(BaseResponse.onSuccess(response));
     }
 }

--- a/src/main/java/com/mini/buting/api/team/domain/Gender.java
+++ b/src/main/java/com/mini/buting/api/team/domain/Gender.java
@@ -1,6 +1,5 @@
 package com.mini.buting.api.team.domain;
 
-import com.mini.buting.api.member.domain.Member;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -10,8 +9,7 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum Gender {
-    MALE("남성"),
-    FEMALE("여성");
+    MALE("남성"), FEMALE("여성");
 
     private final String displayName;
 

--- a/src/main/java/com/mini/buting/api/team/domain/Gender.java
+++ b/src/main/java/com/mini/buting/api/team/domain/Gender.java
@@ -1,0 +1,29 @@
+package com.mini.buting.api.team.domain;
+
+import com.mini.buting.api.member.domain.Member;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 팀의 성별 (팀장의 성별에 따라 자동 결정)
+ */
+@Getter
+@RequiredArgsConstructor
+public enum Gender {
+    MALE("남성"),
+    FEMALE("여성");
+
+    private final String displayName;
+
+    /**
+     * Member의 Gender를 Team의 Gender로 변환
+     */
+    public static Gender fromMemberGender(com.mini.buting.api.member.domain.Gender memberGender) {
+        return switch (memberGender) {
+            case M -> MALE;
+            case W -> FEMALE;
+        };
+    }
+}
+
+

--- a/src/main/java/com/mini/buting/api/team/domain/Team.java
+++ b/src/main/java/com/mini/buting/api/team/domain/Team.java
@@ -100,8 +100,8 @@ public class Team extends BaseTimeEntity {
     @Builder
     public Team(String title, Byte preferredAgeMin, Byte preferredAgeMax,
                     Byte preferredEntryYearMin, Byte preferredEntryYearMax, TeamSize teamSize,
-                    com.mini.buting.api.team.domain.Gender gender, TeamMood preferredMood, String description, Boolean isOpen,
-                    Member leader) {
+                    com.mini.buting.api.team.domain.Gender gender, TeamMood preferredMood,
+                    String description, Boolean isOpen, Member leader) {
         this.title = title;
         this.preferredAgeMin = preferredAgeMin;
         this.preferredAgeMax = preferredAgeMax;

--- a/src/main/java/com/mini/buting/api/team/domain/Team.java
+++ b/src/main/java/com/mini/buting/api/team/domain/Team.java
@@ -70,11 +70,11 @@ public class Team extends BaseTimeEntity {
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
-    private Gender gender;
+    private com.mini.buting.api.team.domain.Gender gender;
 
     @Enumerated(EnumType.STRING)
     @Column(name = "preferred_mood", nullable = false)
-    private PreferredMood preferredMood;
+    private TeamMood preferredMood;
 
     @Column(nullable = false)
     private String description;
@@ -100,7 +100,7 @@ public class Team extends BaseTimeEntity {
     @Builder
     public Team(String title, Byte preferredAgeMin, Byte preferredAgeMax,
                     Byte preferredEntryYearMin, Byte preferredEntryYearMax, TeamSize teamSize,
-                    Gender gender, PreferredMood preferredMood, String description, Boolean isOpen,
+                    com.mini.buting.api.team.domain.Gender gender, TeamMood preferredMood, String description, Boolean isOpen,
                     Member leader) {
         this.title = title;
         this.preferredAgeMin = preferredAgeMin;
@@ -122,6 +122,10 @@ public class Team extends BaseTimeEntity {
 
     public void updateDescription(String description) {
         this.description = description;
+    }
+
+    public void activate() {
+        this.isOpen = true;
     }
 
     public int getCurrentMemberCount() {
@@ -155,43 +159,5 @@ public class Team extends BaseTimeEntity {
 
     public boolean isMember(Member member) {
         return teamMembers.stream().anyMatch(tm -> tm.getMember().equals(member));
-    }
-
-    // Enum 정의
-    @Getter
-    public enum TeamSize {
-        TWO_ON_TWO("2:2", 2), THREE_ON_THREE("3:3", 3), FOUR_ON_FOUR("4:4", 4), FIVE_ON_FIVE("5:5",
-                        5), SIX_ON_SIX("6:6", 6);
-
-        private final String displayName;
-        private final int size;
-
-        TeamSize(String displayName, int size) {
-            this.displayName = displayName;
-            this.size = size;
-        }
-    }
-
-
-    public enum Gender {
-        MALE, FEMALE
-    }
-
-
-    public enum PreferredMood {
-        ROMANTIC_TENSION("연애 텐션"), FRIENDSHIP_TENSION("친구 텐션"), FLIRTY_TENSION(
-                        "썸 텐션"), CALM_TENSION("차분 텐션"), HIGH_TENSION("하이 텐션"), DRINKING_TENSION(
-                        "술 텐션"), EMOTIONAL_TENSION("감성 텐션"), ANY_MOOD("어떤 분위기든 상관없음");
-
-        private final String description;
-
-        PreferredMood(String description) {
-            this.description = description;
-        }
-
-        // 화면에 표시할 한글명 반환
-        public String getDisplayName() {
-            return this.description;
-        }
     }
 }

--- a/src/main/java/com/mini/buting/api/team/domain/TeamInvitation.java
+++ b/src/main/java/com/mini/buting/api/team/domain/TeamInvitation.java
@@ -15,18 +15,16 @@ import java.time.LocalDateTime;
 
 @Entity
 @Table(name = "team_invitation",
-        indexes = {
-                @Index(name = "idx_team_invitation_team", columnList = "team_id"),
-                @Index(name = "idx_team_invitation_inviter", columnList = "inviter_id"),
-                @Index(name = "idx_team_invitation_invitee", columnList = "invitee_id"),
-                @Index(name = "idx_team_invitation_status", columnList = "status"),
-                @Index(name = "idx_team_invitation_created", columnList = "created_at")
-        },
-        uniqueConstraints = {
-                @UniqueConstraint(name = "uk_team_invitation_pair", 
-                                columnNames = {"team_id", "invitee_id"})
-        }
-)
+                indexes = {@Index(name = "idx_team_invitation_team", columnList = "team_id"),
+                                @Index(name = "idx_team_invitation_inviter",
+                                                columnList = "inviter_id"),
+                                @Index(name = "idx_team_invitation_invitee",
+                                                columnList = "invitee_id"),
+                                @Index(name = "idx_team_invitation_status", columnList = "status"),
+                                @Index(name = "idx_team_invitation_created",
+                                                columnList = "created_at")}, uniqueConstraints = {
+                @UniqueConstraint(name = "uk_team_invitation_pair",
+                                columnNames = {"team_id", "invitee_id"})})
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Comment("팀 초대 관리 테이블")
@@ -53,19 +51,19 @@ public class TeamInvitation extends BaseTimeEntity {
     // 연관관계
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "team_id", nullable = false,
-                foreignKey = @ForeignKey(name = "FK_team_invitation_team"))
+                    foreignKey = @ForeignKey(name = "FK_team_invitation_team"))
     @Comment("초대된 팀")
     private Team team;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "inviter_id", nullable = false,
-                foreignKey = @ForeignKey(name = "FK_team_invitation_inviter"))
+                    foreignKey = @ForeignKey(name = "FK_team_invitation_inviter"))
     @Comment("초대를 보낸 사람 (팀장)")
     private Member inviter;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "invitee_id", nullable = false,
-                foreignKey = @ForeignKey(name = "FK_team_invitation_invitee"))
+                    foreignKey = @ForeignKey(name = "FK_team_invitation_invitee"))
     @Comment("초대받은 사람")
     private Member invitee;
 

--- a/src/main/java/com/mini/buting/api/team/domain/TeamInvitation.java
+++ b/src/main/java/com/mini/buting/api/team/domain/TeamInvitation.java
@@ -1,0 +1,145 @@
+package com.mini.buting.api.team.domain;
+
+import com.mini.buting.api.member.domain.Member;
+import com.mini.buting.global.common.BaseTimeEntity;
+import com.mini.buting.global.exception.BaseException;
+import com.mini.buting.global.response.BaseResponseStatus;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Comment;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "team_invitation",
+        indexes = {
+                @Index(name = "idx_team_invitation_team", columnList = "team_id"),
+                @Index(name = "idx_team_invitation_inviter", columnList = "inviter_id"),
+                @Index(name = "idx_team_invitation_invitee", columnList = "invitee_id"),
+                @Index(name = "idx_team_invitation_status", columnList = "status"),
+                @Index(name = "idx_team_invitation_created", columnList = "created_at")
+        },
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uk_team_invitation_pair", 
+                                columnNames = {"team_id", "invitee_id"})
+        }
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Comment("팀 초대 관리 테이블")
+public class TeamInvitation extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Comment("초대 식별자")
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    @Comment("초대 상태")
+    private InvitationStatus status;
+
+    @Column(name = "responded_at")
+    @Comment("응답 시간")
+    private LocalDateTime respondedAt;
+
+    @Column(name = "expired_at")
+    @Comment("만료 시간")
+    private LocalDateTime expiredAt;
+
+    // 연관관계
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "team_id", nullable = false,
+                foreignKey = @ForeignKey(name = "FK_team_invitation_team"))
+    @Comment("초대된 팀")
+    private Team team;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "inviter_id", nullable = false,
+                foreignKey = @ForeignKey(name = "FK_team_invitation_inviter"))
+    @Comment("초대를 보낸 사람 (팀장)")
+    private Member inviter;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "invitee_id", nullable = false,
+                foreignKey = @ForeignKey(name = "FK_team_invitation_invitee"))
+    @Comment("초대받은 사람")
+    private Member invitee;
+
+    @Builder
+    public TeamInvitation(Team team, Member inviter, Member invitee) {
+        this.team = team;
+        this.inviter = inviter;
+        this.invitee = invitee;
+        this.status = InvitationStatus.PENDING;
+        this.expiredAt = LocalDateTime.now().plusDays(7); // 7일 후 만료
+    }
+
+    // 비즈니스 메서드
+    public void accept() {
+        validatePendingStatus();
+        this.status = InvitationStatus.ACCEPTED;
+        this.respondedAt = LocalDateTime.now();
+    }
+
+    public void reject() {
+        validatePendingStatus();
+        this.status = InvitationStatus.REJECTED;
+        this.respondedAt = LocalDateTime.now();
+    }
+
+    public boolean isExpired() {
+        return expiredAt.isBefore(LocalDateTime.now());
+    }
+
+    public void expireIfNeeded() {
+        if (isExpired() && status == InvitationStatus.PENDING) {
+            this.status = InvitationStatus.EXPIRED;
+            this.respondedAt = LocalDateTime.now();
+        }
+    }
+
+    public boolean isPending() {
+        return status == InvitationStatus.PENDING;
+    }
+
+    public boolean isAccepted() {
+        return status == InvitationStatus.ACCEPTED;
+    }
+
+    public boolean canBeProcessed() {
+        return isPending() && !isExpired();
+    }
+
+    public boolean involves(Member member) {
+        return inviter.equals(member) || invitee.equals(member);
+    }
+
+    public boolean isInviter(Member member) {
+        return inviter.equals(member);
+    }
+
+    public boolean isInvitee(Member member) {
+        return invitee.equals(member);
+    }
+
+    private void validatePendingStatus() {
+        if (status != InvitationStatus.PENDING) {
+            throw new BaseException(BaseResponseStatus.TEAM_INVITATION_NOT_PENDING);
+        }
+        if (isExpired()) {
+            throw new BaseException(BaseResponseStatus.TEAM_INVITATION_EXPIRED);
+        }
+    }
+
+    // Enum 정의
+    public enum InvitationStatus {
+        PENDING,    // 대기중
+        ACCEPTED,   // 수락됨
+        REJECTED,   // 거절됨
+        EXPIRED     // 만료됨
+    }
+}

--- a/src/main/java/com/mini/buting/api/team/domain/TeamMood.java
+++ b/src/main/java/com/mini/buting/api/team/domain/TeamMood.java
@@ -1,0 +1,23 @@
+package com.mini.buting.api.team.domain;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor; /**
+ * 팀의 선호 분위기
+ */
+@Getter
+public enum TeamMood {
+    ROMANTIC_TENSION("연애 텐션"), FRIENDSHIP_TENSION("친구 텐션"), FLIRTY_TENSION(
+                    "썸 텐션"), CALM_TENSION("차분 텐션"), HIGH_TENSION("하이 텐션"), DRINKING_TENSION(
+                    "술 텐션"), EMOTIONAL_TENSION("감성 텐션"), ANY_MOOD("어떤 분위기든 상관없음");
+
+    private final String description;
+
+    TeamMood(String description) {
+        this.description = description;
+    }
+
+    // 화면에 표시할 한글명 반환
+    public String getDisplayName() {
+        return this.description;
+    }
+}

--- a/src/main/java/com/mini/buting/api/team/domain/TeamMood.java
+++ b/src/main/java/com/mini/buting/api/team/domain/TeamMood.java
@@ -1,14 +1,16 @@
 package com.mini.buting.api.team.domain;
 
 import lombok.Getter;
-import lombok.RequiredArgsConstructor; /**
+import lombok.RequiredArgsConstructor;
+
+/**
  * 팀의 선호 분위기
  */
 @Getter
 public enum TeamMood {
-    ROMANTIC_TENSION("연애 텐션"), FRIENDSHIP_TENSION("친구 텐션"), FLIRTY_TENSION(
-                    "썸 텐션"), CALM_TENSION("차분 텐션"), HIGH_TENSION("하이 텐션"), DRINKING_TENSION(
-                    "술 텐션"), EMOTIONAL_TENSION("감성 텐션"), ANY_MOOD("어떤 분위기든 상관없음");
+    ROMANTIC_TENSION("연애 텐션"), FRIENDSHIP_TENSION("친구 텐션"), FLIRTY_TENSION("썸 텐션"), CALM_TENSION(
+                    "차분 텐션"), HIGH_TENSION("하이 텐션"), DRINKING_TENSION("술 텐션"), EMOTIONAL_TENSION(
+                    "감성 텐션"), ANY_MOOD("어떤 분위기든 상관없음");
 
     private final String description;
 

--- a/src/main/java/com/mini/buting/api/team/domain/TeamSize.java
+++ b/src/main/java/com/mini/buting/api/team/domain/TeamSize.java
@@ -1,17 +1,16 @@
 package com.mini.buting.api.team.domain;
 
 import lombok.Getter;
-import lombok.RequiredArgsConstructor; /**
+import lombok.RequiredArgsConstructor;
+
+/**
  * 팀 크기
  */
 @Getter
 @RequiredArgsConstructor
 public enum TeamSize {
-    TWO_ON_TWO("2:2", 2),
-    THREE_ON_THREE("3:3", 3),
-    FOUR_ON_FOUR("4:4", 4),
-    FIVE_ON_FIVE("5:5", 5),
-    SIX_ON_SIX("6:6", 6);
+    TWO_ON_TWO("2:2", 2), THREE_ON_THREE("3:3", 3), FOUR_ON_FOUR("4:4", 4), FIVE_ON_FIVE("5:5",
+                    5), SIX_ON_SIX("6:6", 6);
 
     private final String displayName;
     private final int size;

--- a/src/main/java/com/mini/buting/api/team/domain/TeamSize.java
+++ b/src/main/java/com/mini/buting/api/team/domain/TeamSize.java
@@ -1,0 +1,18 @@
+package com.mini.buting.api.team.domain;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor; /**
+ * 팀 크기
+ */
+@Getter
+@RequiredArgsConstructor
+public enum TeamSize {
+    TWO_ON_TWO("2:2", 2),
+    THREE_ON_THREE("3:3", 3),
+    FOUR_ON_FOUR("4:4", 4),
+    FIVE_ON_FIVE("5:5", 5),
+    SIX_ON_SIX("6:6", 6);
+
+    private final String displayName;
+    private final int size;
+}

--- a/src/main/java/com/mini/buting/api/team/dto/request/TeamRequestDto.java
+++ b/src/main/java/com/mini/buting/api/team/dto/request/TeamRequestDto.java
@@ -10,44 +10,37 @@ import java.util.List;
 public class TeamRequestDto {
 
     @Builder
-    public record CreateTeamRequest(
-            @NotBlank(message = "팀 제목은 필수입니다.")
-            @Size(max = 50, message = "팀 제목은 50자를 초과할 수 없습니다.")
-            String title,
+    public record CreateTeamRequest(@NotBlank(message = "팀 제목은 필수입니다.") @Size(max = 50,
+                    message = "팀 제목은 50자를 초과할 수 없습니다.") String title,
 
-            @NotBlank(message = "팀 소개는 필수입니다.")
-            @Size(max = 255, message = "팀 소개는 255자를 초과할 수 없습니다.")
-            String description,
+                                    @NotBlank(message = "팀 소개는 필수입니다.") @Size(max = 255,
+                                                    message = "팀 소개는 255자를 초과할 수 없습니다.") String description,
 
-            @NotNull(message = "선호하는 분위기를 선택해주세요.")
-            TeamMood preferredMood,
+                                    @NotNull(message = "선호하는 분위기를 선택해주세요.") TeamMood preferredMood,
 
-            @NotNull(message = "팀 크기를 선택해주세요.")
-            TeamSize teamSize,
+                                    @NotNull(message = "팀 크기를 선택해주세요.") TeamSize teamSize,
 
-            @NotNull(message = "최소 나이를 입력해주세요.")
-            @Min(value = 18, message = "최소 나이는 18세 이상이어야 합니다.")
-            @Max(value = 100, message = "최소 나이는 100세 이하여야 합니다.")
-            Integer preferredAgeMin,
+                                    @NotNull(message = "최소 나이를 입력해주세요.") @Min(value = 18,
+                                                    message = "최소 나이는 18세 이상이어야 합니다.") @Max(
+                                                    value = 100,
+                                                    message = "최소 나이는 100세 이하여야 합니다.") Integer preferredAgeMin,
 
-            @NotNull(message = "최대 나이를 입력해주세요.")
-            @Min(value = 18, message = "최대 나이는 18세 이상이어야 합니다.")
-            @Max(value = 100, message = "최대 나이는 100세 이하여야 합니다.")
-            Integer preferredAgeMax,
+                                    @NotNull(message = "최대 나이를 입력해주세요.") @Min(value = 18,
+                                                    message = "최대 나이는 18세 이상이어야 합니다.") @Max(
+                                                    value = 100,
+                                                    message = "최대 나이는 100세 이하여야 합니다.") Integer preferredAgeMax,
 
-            @NotNull(message = "최소 학번을 입력해주세요.")
-            @Min(value = 0, message = "최소 학번은 0 이상이어야 합니다.")
-            @Max(value = 99, message = "최소 학번은 99 이하여야 합니다.")
-            Integer preferredEntryYearMin,
+                                    @NotNull(message = "최소 학번을 입력해주세요.") @Min(value = 0,
+                                                    message = "최소 학번은 0 이상이어야 합니다.") @Max(
+                                                    value = 99,
+                                                    message = "최소 학번은 99 이하여야 합니다.") Integer preferredEntryYearMin,
 
-            @NotNull(message = "최대 학번을 입력해주세요.")
-            @Min(value = 0, message = "최대 학번은 0 이상이어야 합니다.")
-            @Max(value = 99, message = "최대 학번은 99 이하여야 합니다.")
-            Integer preferredEntryYearMax,
+                                    @NotNull(message = "최대 학번을 입력해주세요.") @Min(value = 0,
+                                                    message = "최대 학번은 0 이상이어야 합니다.") @Max(
+                                                    value = 99,
+                                                    message = "최대 학번은 99 이하여야 합니다.") Integer preferredEntryYearMax,
 
-            @NotEmpty(message = "초대할 멤버를 선택해주세요.")
-            List<Long> inviteMemberIds
-    ) {
+                                    @NotEmpty(message = "초대할 멤버를 선택해주세요.") List<Long> inviteMemberIds) {
         public CreateTeamRequest {
             // 나이 범위 검증
             if (preferredAgeMin != null && preferredAgeMax != null && preferredAgeMin > preferredAgeMax) {
@@ -64,23 +57,22 @@ public class TeamRequestDto {
                 int expectedInviteCount = teamSize.getSize() - 1;
                 if (inviteMemberIds.size() != expectedInviteCount) {
                     throw new IllegalArgumentException(
-                            String.format("팀 크기 %s에 맞는 %d명을 초대해야 합니다. (현재: %d명)", 
-                                    teamSize.getDisplayName(), expectedInviteCount, inviteMemberIds.size())
-                    );
+                                    String.format("팀 크기 %s에 맞는 %d명을 초대해야 합니다. (현재: %d명)",
+                                                    teamSize.getDisplayName(), expectedInviteCount,
+                                                    inviteMemberIds.size()));
                 }
             }
         }
     }
 
+
     @Builder
     public record SearchFriendsRequest(
-            @Size(max = 50, message = "검색어는 50자를 초과할 수 없습니다.")
-            String keyword
-    ) {}
+                    @Size(max = 50, message = "검색어는 50자를 초과할 수 없습니다.") String keyword) {
+    }
 
-    @Builder  
-    public record RespondToInvitationRequest(
-            @NotNull(message = "응답은 필수입니다.")
-            Boolean accept
-    ) {}
+
+    @Builder
+    public record RespondToInvitationRequest(@NotNull(message = "응답은 필수입니다.") Boolean accept) {
+    }
 }

--- a/src/main/java/com/mini/buting/api/team/dto/request/TeamRequestDto.java
+++ b/src/main/java/com/mini/buting/api/team/dto/request/TeamRequestDto.java
@@ -1,0 +1,86 @@
+package com.mini.buting.api.team.dto.request;
+
+import com.mini.buting.api.team.domain.TeamMood;
+import com.mini.buting.api.team.domain.TeamSize;
+import jakarta.validation.constraints.*;
+import lombok.Builder;
+
+import java.util.List;
+
+public class TeamRequestDto {
+
+    @Builder
+    public record CreateTeamRequest(
+            @NotBlank(message = "팀 제목은 필수입니다.")
+            @Size(max = 50, message = "팀 제목은 50자를 초과할 수 없습니다.")
+            String title,
+
+            @NotBlank(message = "팀 소개는 필수입니다.")
+            @Size(max = 255, message = "팀 소개는 255자를 초과할 수 없습니다.")
+            String description,
+
+            @NotNull(message = "선호하는 분위기를 선택해주세요.")
+            TeamMood preferredMood,
+
+            @NotNull(message = "팀 크기를 선택해주세요.")
+            TeamSize teamSize,
+
+            @NotNull(message = "최소 나이를 입력해주세요.")
+            @Min(value = 18, message = "최소 나이는 18세 이상이어야 합니다.")
+            @Max(value = 100, message = "최소 나이는 100세 이하여야 합니다.")
+            Integer preferredAgeMin,
+
+            @NotNull(message = "최대 나이를 입력해주세요.")
+            @Min(value = 18, message = "최대 나이는 18세 이상이어야 합니다.")
+            @Max(value = 100, message = "최대 나이는 100세 이하여야 합니다.")
+            Integer preferredAgeMax,
+
+            @NotNull(message = "최소 학번을 입력해주세요.")
+            @Min(value = 0, message = "최소 학번은 0 이상이어야 합니다.")
+            @Max(value = 99, message = "최소 학번은 99 이하여야 합니다.")
+            Integer preferredEntryYearMin,
+
+            @NotNull(message = "최대 학번을 입력해주세요.")
+            @Min(value = 0, message = "최대 학번은 0 이상이어야 합니다.")
+            @Max(value = 99, message = "최대 학번은 99 이하여야 합니다.")
+            Integer preferredEntryYearMax,
+
+            @NotEmpty(message = "초대할 멤버를 선택해주세요.")
+            List<Long> inviteMemberIds
+    ) {
+        public CreateTeamRequest {
+            // 나이 범위 검증
+            if (preferredAgeMin != null && preferredAgeMax != null && preferredAgeMin > preferredAgeMax) {
+                throw new IllegalArgumentException("최소 나이는 최대 나이보다 클 수 없습니다.");
+            }
+
+            // 학번 범위 검증  
+            if (preferredEntryYearMin != null && preferredEntryYearMax != null && preferredEntryYearMin > preferredEntryYearMax) {
+                throw new IllegalArgumentException("최소 학번은 최대 학번보다 클 수 없습니다.");
+            }
+
+            // 초대 인원 수 검증 (팀 크기 - 1이어야 함)
+            if (teamSize != null && inviteMemberIds != null) {
+                int expectedInviteCount = teamSize.getSize() - 1;
+                if (inviteMemberIds.size() != expectedInviteCount) {
+                    throw new IllegalArgumentException(
+                            String.format("팀 크기 %s에 맞는 %d명을 초대해야 합니다. (현재: %d명)", 
+                                    teamSize.getDisplayName(), expectedInviteCount, inviteMemberIds.size())
+                    );
+                }
+            }
+        }
+    }
+
+    @Builder
+    public record SearchFriendsRequest(
+            @Size(max = 50, message = "검색어는 50자를 초과할 수 없습니다.")
+            String keyword
+    ) {}
+
+    @Builder  
+    public record RespondToInvitationRequest(
+            @NotNull(message = "응답은 필수입니다.")
+            Boolean accept
+    ) {}
+}

--- a/src/main/java/com/mini/buting/api/team/dto/response/TeamResponseDto.java
+++ b/src/main/java/com/mini/buting/api/team/dto/response/TeamResponseDto.java
@@ -1,0 +1,98 @@
+package com.mini.buting.api.team.dto.response;
+
+import com.mini.buting.api.team.domain.*;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public class TeamResponseDto {
+
+    @Builder
+    public record CreateTeamResponse(
+            Long teamId,
+            String title,
+            String description,
+            TeamSize teamSize,
+            TeamMood preferredMood,
+            Integer preferredAgeMin,
+            Integer preferredAgeMax,
+            Integer preferredEntryYearMin,
+            Integer preferredEntryYearMax,
+            Boolean isOpen,
+            List<TeamInvitationInfo> sentInvitations
+    ) {}
+
+    @Builder
+    public record TeamInvitationInfo(
+            Long invitationId,
+            Long inviteeId,
+            String inviteeName,
+            String inviteeNickname,
+            TeamInvitation.InvitationStatus status,
+            LocalDateTime createdAt,
+            LocalDateTime expiredAt
+    ) {}
+
+    @Builder
+    public record SearchableFriend(
+            Long memberId,
+            String nickname,
+            String universityEmail,
+            String bio,
+            Integer age,
+            String genderDisplayName,
+            String universityName,
+            String collegeName,
+            List<String> personalityTypes
+    ) {}
+
+    @Builder
+    public record SearchFriendsResponse(
+            List<SearchableFriend> friends,
+            Integer totalCount
+    ) {}
+
+    @Builder
+    public record TeamInvitationDetailResponse(
+            Long invitationId,
+            TeamInfo teamInfo,
+            MemberInfo inviterInfo,
+            TeamInvitation.InvitationStatus status,
+            LocalDateTime createdAt,
+            LocalDateTime expiredAt,
+            Boolean isExpired
+    ) {}
+
+    @Builder
+    public record TeamInfo(
+            Long teamId,
+            String title,
+            String description,
+            TeamSize teamSize,
+            TeamMood preferredMood,
+            Integer preferredAgeMin,
+            Integer preferredAgeMax,
+            Integer preferredEntryYearMin,
+            Integer preferredEntryYearMax,
+            Integer currentMemberCount,
+            Integer targetMemberCount
+    ) {}
+
+    @Builder
+    public record MemberInfo(
+            Long memberId,
+            String nickname,
+            Integer age,
+            String bio,
+            String universityName,
+            String collegeName
+    ) {}
+
+    @Builder
+    public record RespondToInvitationResponse(
+            Long invitationId,
+            TeamInvitation.InvitationStatus status,
+            String message
+    ) {}
+}

--- a/src/main/java/com/mini/buting/api/team/dto/response/TeamResponseDto.java
+++ b/src/main/java/com/mini/buting/api/team/dto/response/TeamResponseDto.java
@@ -9,90 +9,60 @@ import java.util.List;
 public class TeamResponseDto {
 
     @Builder
-    public record CreateTeamResponse(
-            Long teamId,
-            String title,
-            String description,
-            TeamSize teamSize,
-            TeamMood preferredMood,
-            Integer preferredAgeMin,
-            Integer preferredAgeMax,
-            Integer preferredEntryYearMin,
-            Integer preferredEntryYearMax,
-            Boolean isOpen,
-            List<TeamInvitationInfo> sentInvitations
-    ) {}
+    public record CreateTeamResponse(Long teamId, String title, String description,
+                                     TeamSize teamSize, TeamMood preferredMood,
+                                     Integer preferredAgeMin, Integer preferredAgeMax,
+                                     Integer preferredEntryYearMin, Integer preferredEntryYearMax,
+                                     Boolean isOpen, List<TeamInvitationInfo> sentInvitations) {
+    }
+
 
     @Builder
-    public record TeamInvitationInfo(
-            Long invitationId,
-            Long inviteeId,
-            String inviteeName,
-            String inviteeNickname,
-            TeamInvitation.InvitationStatus status,
-            LocalDateTime createdAt,
-            LocalDateTime expiredAt
-    ) {}
+    public record TeamInvitationInfo(Long invitationId, Long inviteeId, String inviteeName,
+                                     String inviteeNickname, TeamInvitation.InvitationStatus status,
+                                     LocalDateTime createdAt, LocalDateTime expiredAt) {
+    }
+
 
     @Builder
-    public record SearchableFriend(
-            Long memberId,
-            String nickname,
-            String universityEmail,
-            String bio,
-            Integer age,
-            String genderDisplayName,
-            String universityName,
-            String collegeName,
-            List<String> personalityTypes
-    ) {}
+    public record SearchableFriend(Long memberId, String nickname, String universityEmail,
+                                   String bio, Integer age, String genderDisplayName,
+                                   String universityName, String collegeName,
+                                   List<String> personalityTypes) {
+    }
+
 
     @Builder
-    public record SearchFriendsResponse(
-            List<SearchableFriend> friends,
-            Integer totalCount
-    ) {}
+    public record SearchFriendsResponse(List<SearchableFriend> friends, Integer totalCount) {
+    }
+
 
     @Builder
-    public record TeamInvitationDetailResponse(
-            Long invitationId,
-            TeamInfo teamInfo,
-            MemberInfo inviterInfo,
-            TeamInvitation.InvitationStatus status,
-            LocalDateTime createdAt,
-            LocalDateTime expiredAt,
-            Boolean isExpired
-    ) {}
+    public record TeamInvitationDetailResponse(Long invitationId, TeamInfo teamInfo,
+                                               MemberInfo inviterInfo,
+                                               TeamInvitation.InvitationStatus status,
+                                               LocalDateTime createdAt, LocalDateTime expiredAt,
+                                               Boolean isExpired) {
+    }
+
 
     @Builder
-    public record TeamInfo(
-            Long teamId,
-            String title,
-            String description,
-            TeamSize teamSize,
-            TeamMood preferredMood,
-            Integer preferredAgeMin,
-            Integer preferredAgeMax,
-            Integer preferredEntryYearMin,
-            Integer preferredEntryYearMax,
-            Integer currentMemberCount,
-            Integer targetMemberCount
-    ) {}
+    public record TeamInfo(Long teamId, String title, String description, TeamSize teamSize,
+                           TeamMood preferredMood, Integer preferredAgeMin, Integer preferredAgeMax,
+                           Integer preferredEntryYearMin, Integer preferredEntryYearMax,
+                           Integer currentMemberCount, Integer targetMemberCount) {
+    }
+
 
     @Builder
-    public record MemberInfo(
-            Long memberId,
-            String nickname,
-            Integer age,
-            String bio,
-            String universityName,
-            String collegeName
-    ) {}
+    public record MemberInfo(Long memberId, String nickname, Integer age, String bio,
+                             String universityName, String collegeName) {
+    }
+
 
     @Builder
-    public record RespondToInvitationResponse(
-            Long invitationId,
-            TeamInvitation.InvitationStatus status,
-            String message
-    ) {}
+    public record RespondToInvitationResponse(Long invitationId,
+                                              TeamInvitation.InvitationStatus status,
+                                              String message) {
+    }
 }

--- a/src/main/java/com/mini/buting/api/team/repository/TeamInvitationRepository.java
+++ b/src/main/java/com/mini/buting/api/team/repository/TeamInvitationRepository.java
@@ -18,22 +18,15 @@ public interface TeamInvitationRepository extends JpaRepository<TeamInvitation, 
     /**
      * 특정 팀의 모든 초대 조회
      */
-    @Query("SELECT ti FROM TeamInvitation ti " +
-           "JOIN FETCH ti.invitee " +
-           "WHERE ti.team = :team")
+    @Query("SELECT ti FROM TeamInvitation ti " + "JOIN FETCH ti.invitee " + "WHERE ti.team = :team")
     List<TeamInvitation> findByTeamWithInvitee(@Param("team") Team team);
 
     /**
      * 특정 멤버가 받은 대기중인 초대들 조회
      */
-    @Query("SELECT ti FROM TeamInvitation ti " +
-           "JOIN FETCH ti.team t " +
-           "JOIN FETCH ti.inviter " +
-           "WHERE ti.invitee = :invitee " +
-           "AND ti.status = 'PENDING' " +
-           "AND ti.expiredAt > :now")
-    List<TeamInvitation> findPendingInvitationsByInvitee(@Param("invitee") Member invitee, 
-                                                         @Param("now") LocalDateTime now);
+    @Query("SELECT ti FROM TeamInvitation ti " + "JOIN FETCH ti.team t " + "JOIN FETCH ti.inviter " + "WHERE ti.invitee = :invitee " + "AND ti.status = 'PENDING' " + "AND ti.expiredAt > :now")
+    List<TeamInvitation> findPendingInvitationsByInvitee(@Param("invitee") Member invitee,
+                    @Param("now") LocalDateTime now);
 
     /**
      * 팀과 초대받은 사람으로 초대 조회
@@ -43,34 +36,25 @@ public interface TeamInvitationRepository extends JpaRepository<TeamInvitation, 
     /**
      * 초대 ID와 초대받은 사람으로 초대 조회 (권한 확인용)
      */
-    @Query("SELECT ti FROM TeamInvitation ti " +
-           "JOIN FETCH ti.team " +
-           "JOIN FETCH ti.inviter " +
-           "WHERE ti.id = :invitationId AND ti.invitee = :invitee")
-    Optional<TeamInvitation> findByIdAndInvitee(@Param("invitationId") Long invitationId, 
-                                                @Param("invitee") Member invitee);
+    @Query("SELECT ti FROM TeamInvitation ti " + "JOIN FETCH ti.team " + "JOIN FETCH ti.inviter " + "WHERE ti.id = :invitationId AND ti.invitee = :invitee")
+    Optional<TeamInvitation> findByIdAndInvitee(@Param("invitationId") Long invitationId,
+                    @Param("invitee") Member invitee);
 
     /**
      * 특정 팀의 수락된 초대 수 조회
      */
-    @Query("SELECT COUNT(ti) FROM TeamInvitation ti " +
-           "WHERE ti.team = :team AND ti.status = 'ACCEPTED'")
+    @Query("SELECT COUNT(ti) FROM TeamInvitation ti " + "WHERE ti.team = :team AND ti.status = 'ACCEPTED'")
     long countAcceptedInvitationsByTeam(@Param("team") Team team);
 
     /**
      * 만료된 대기중 초대들 조회
      */
-    @Query("SELECT ti FROM TeamInvitation ti " +
-           "WHERE ti.status = 'PENDING' " +
-           "AND ti.expiredAt <= :now")
+    @Query("SELECT ti FROM TeamInvitation ti " + "WHERE ti.status = 'PENDING' " + "AND ti.expiredAt <= :now")
     List<TeamInvitation> findExpiredPendingInvitations(@Param("now") LocalDateTime now);
 
     /**
      * 특정 팀의 모든 초대가 수락되었는지 확인
      */
-    @Query("SELECT CASE WHEN COUNT(ti) = 0 THEN true ELSE false END " +
-           "FROM TeamInvitation ti " +
-           "WHERE ti.team = :team " +
-           "AND ti.status IN ('PENDING', 'REJECTED')")
+    @Query("SELECT CASE WHEN COUNT(ti) = 0 THEN true ELSE false END " + "FROM TeamInvitation ti " + "WHERE ti.team = :team " + "AND ti.status IN ('PENDING', 'REJECTED')")
     boolean areAllInvitationsAccepted(@Param("team") Team team);
 }

--- a/src/main/java/com/mini/buting/api/team/repository/TeamInvitationRepository.java
+++ b/src/main/java/com/mini/buting/api/team/repository/TeamInvitationRepository.java
@@ -1,0 +1,76 @@
+package com.mini.buting.api.team.repository;
+
+import com.mini.buting.api.team.domain.Team;
+import com.mini.buting.api.team.domain.TeamInvitation;
+import com.mini.buting.api.member.domain.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface TeamInvitationRepository extends JpaRepository<TeamInvitation, Long> {
+
+    /**
+     * 특정 팀의 모든 초대 조회
+     */
+    @Query("SELECT ti FROM TeamInvitation ti " +
+           "JOIN FETCH ti.invitee " +
+           "WHERE ti.team = :team")
+    List<TeamInvitation> findByTeamWithInvitee(@Param("team") Team team);
+
+    /**
+     * 특정 멤버가 받은 대기중인 초대들 조회
+     */
+    @Query("SELECT ti FROM TeamInvitation ti " +
+           "JOIN FETCH ti.team t " +
+           "JOIN FETCH ti.inviter " +
+           "WHERE ti.invitee = :invitee " +
+           "AND ti.status = 'PENDING' " +
+           "AND ti.expiredAt > :now")
+    List<TeamInvitation> findPendingInvitationsByInvitee(@Param("invitee") Member invitee, 
+                                                         @Param("now") LocalDateTime now);
+
+    /**
+     * 팀과 초대받은 사람으로 초대 조회
+     */
+    Optional<TeamInvitation> findByTeamAndInvitee(Team team, Member invitee);
+
+    /**
+     * 초대 ID와 초대받은 사람으로 초대 조회 (권한 확인용)
+     */
+    @Query("SELECT ti FROM TeamInvitation ti " +
+           "JOIN FETCH ti.team " +
+           "JOIN FETCH ti.inviter " +
+           "WHERE ti.id = :invitationId AND ti.invitee = :invitee")
+    Optional<TeamInvitation> findByIdAndInvitee(@Param("invitationId") Long invitationId, 
+                                                @Param("invitee") Member invitee);
+
+    /**
+     * 특정 팀의 수락된 초대 수 조회
+     */
+    @Query("SELECT COUNT(ti) FROM TeamInvitation ti " +
+           "WHERE ti.team = :team AND ti.status = 'ACCEPTED'")
+    long countAcceptedInvitationsByTeam(@Param("team") Team team);
+
+    /**
+     * 만료된 대기중 초대들 조회
+     */
+    @Query("SELECT ti FROM TeamInvitation ti " +
+           "WHERE ti.status = 'PENDING' " +
+           "AND ti.expiredAt <= :now")
+    List<TeamInvitation> findExpiredPendingInvitations(@Param("now") LocalDateTime now);
+
+    /**
+     * 특정 팀의 모든 초대가 수락되었는지 확인
+     */
+    @Query("SELECT CASE WHEN COUNT(ti) = 0 THEN true ELSE false END " +
+           "FROM TeamInvitation ti " +
+           "WHERE ti.team = :team " +
+           "AND ti.status IN ('PENDING', 'REJECTED')")
+    boolean areAllInvitationsAccepted(@Param("team") Team team);
+}

--- a/src/main/java/com/mini/buting/api/team/repository/TeamMemberRepository.java
+++ b/src/main/java/com/mini/buting/api/team/repository/TeamMemberRepository.java
@@ -1,0 +1,39 @@
+package com.mini.buting.api.team.repository;
+
+import com.mini.buting.api.member.domain.Member;
+import com.mini.buting.api.team.domain.Team;
+import com.mini.buting.api.team.domain.TeamMember;
+import com.mini.buting.api.team.domain.TeamMemberId;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface TeamMemberRepository extends JpaRepository<TeamMember, TeamMemberId> {
+    
+    /**
+     * 팀과 멤버로 팀멤버 존재 여부 확인
+     */
+    boolean existsByTeamAndMember(Team team, Member member);
+    
+    /**
+     * 팀의 모든 멤버 조회
+     */
+    List<TeamMember> findByTeam(Team team);
+    
+    /**
+     * 멤버의 모든 팀 조회
+     */
+    List<TeamMember> findByMember(Member member);
+    
+    /**
+     * 팀과 멤버로 팀멤버 삭제
+     */
+    void deleteByTeamAndMember(Team team, Member member);
+
+    @Query("SELECT COUNT(tm) FROM TeamMember tm WHERE tm.team = :team")
+    long countByTeam(@Param("team") Team team);
+}

--- a/src/main/java/com/mini/buting/api/team/repository/TeamMemberRepository.java
+++ b/src/main/java/com/mini/buting/api/team/repository/TeamMemberRepository.java
@@ -13,22 +13,22 @@ import java.util.List;
 
 @Repository
 public interface TeamMemberRepository extends JpaRepository<TeamMember, TeamMemberId> {
-    
+
     /**
      * 팀과 멤버로 팀멤버 존재 여부 확인
      */
     boolean existsByTeamAndMember(Team team, Member member);
-    
+
     /**
      * 팀의 모든 멤버 조회
      */
     List<TeamMember> findByTeam(Team team);
-    
+
     /**
      * 멤버의 모든 팀 조회
      */
     List<TeamMember> findByMember(Member member);
-    
+
     /**
      * 팀과 멤버로 팀멤버 삭제
      */

--- a/src/main/java/com/mini/buting/api/team/repository/TeamRepository.java
+++ b/src/main/java/com/mini/buting/api/team/repository/TeamRepository.java
@@ -25,17 +25,12 @@ public interface TeamRepository extends JpaRepository<Team, Long> {
     /**
      * 팀과 해당 팀의 멤버들을 함께 조회
      */
-    @Query("SELECT t FROM Team t " +
-           "LEFT JOIN FETCH t.teamMembers tm " +
-           "LEFT JOIN FETCH tm.member " +
-           "WHERE t.id = :teamId")
+    @Query("SELECT t FROM Team t " + "LEFT JOIN FETCH t.teamMembers tm " + "LEFT JOIN FETCH tm.member " + "WHERE t.id = :teamId")
     Optional<Team> findByIdWithMembers(@Param("teamId") Long teamId);
 
     /**
      * 팀과 팀장 정보를 함께 조회
      */
-    @Query("SELECT t FROM Team t " +
-           "JOIN FETCH t.leader " +
-           "WHERE t.id = :teamId")
+    @Query("SELECT t FROM Team t " + "JOIN FETCH t.leader " + "WHERE t.id = :teamId")
     Optional<Team> findByIdWithLeader(@Param("teamId") Long teamId);
 }

--- a/src/main/java/com/mini/buting/api/team/repository/TeamRepository.java
+++ b/src/main/java/com/mini/buting/api/team/repository/TeamRepository.java
@@ -1,0 +1,41 @@
+package com.mini.buting.api.team.repository;
+
+import com.mini.buting.api.team.domain.Team;
+import com.mini.buting.api.member.domain.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface TeamRepository extends JpaRepository<Team, Long> {
+
+    /**
+     * 특정 멤버가 팀장으로 있는 팀 조회
+     */
+    Optional<Team> findByLeader(Member leader);
+
+    /**
+     * 특정 멤버가 팀장으로 있는 팀 존재 여부 확인
+     */
+    boolean existsByLeader(Member leader);
+
+    /**
+     * 팀과 해당 팀의 멤버들을 함께 조회
+     */
+    @Query("SELECT t FROM Team t " +
+           "LEFT JOIN FETCH t.teamMembers tm " +
+           "LEFT JOIN FETCH tm.member " +
+           "WHERE t.id = :teamId")
+    Optional<Team> findByIdWithMembers(@Param("teamId") Long teamId);
+
+    /**
+     * 팀과 팀장 정보를 함께 조회
+     */
+    @Query("SELECT t FROM Team t " +
+           "JOIN FETCH t.leader " +
+           "WHERE t.id = :teamId")
+    Optional<Team> findByIdWithLeader(@Param("teamId") Long teamId);
+}

--- a/src/main/java/com/mini/buting/api/team/service/TeamInvitationService.java
+++ b/src/main/java/com/mini/buting/api/team/service/TeamInvitationService.java
@@ -8,7 +8,8 @@ import com.mini.buting.api.team.domain.TeamMember;
 import com.mini.buting.api.team.dto.request.TeamRequestDto;
 import com.mini.buting.api.team.dto.response.TeamResponseDto;
 import com.mini.buting.api.team.repository.TeamInvitationRepository;
-import com.mini.buting.api.team.repository.TeamRepository;
+import com.mini.buting.api.team.repository.TeamMemberRepository;
+import com.mini.buting.api.team.repository.TeamRepository;  // ✅ 추가
 import com.mini.buting.global.exception.BaseException;
 import com.mini.buting.global.response.BaseResponseStatus;
 import lombok.RequiredArgsConstructor;
@@ -27,6 +28,8 @@ public class TeamInvitationService {
 
     private final TeamInvitationRepository teamInvitationRepository;
     private final MemberRepository memberRepository;
+    private final TeamRepository teamRepository;  // ✅ 추가
+    private final TeamMemberRepository teamMemberRepository;
 
     /**
      * 받은 초대 목록 조회
@@ -35,85 +38,122 @@ public class TeamInvitationService {
         log.info("받은 초대 목록 조회 - memberId: {}", memberId);
 
         Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_FOUND));
+                        .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_FOUND));
 
         List<TeamInvitation> invitations = teamInvitationRepository
-                .findPendingInvitationsByInvitee(member, LocalDateTime.now());
+                        .findPendingInvitationsByInvitee(member, LocalDateTime.now());
 
         return invitations.stream()
-                .map(this::convertToDetailResponse)
-                .toList();
+                        .map(this::convertToDetailResponse)
+                        .toList();
     }
 
     /**
-     * 초대 응답 (수락/거절)
+     * 초대 응답 (수락/거절) - 완전 수정 버전
      */
     @Transactional
     public TeamResponseDto.RespondToInvitationResponse respondToInvitation(
-            Long memberId, Long invitationId, TeamRequestDto.RespondToInvitationRequest request) {
+                    Long memberId, Long invitationId, TeamRequestDto.RespondToInvitationRequest request) {
 
-        log.info("초대 응답 - memberId: {}, invitationId: {}, accept: {}", 
-                memberId, invitationId, request.accept());
+        log.info("초대 응답 - memberId: {}, invitationId: {}, accept: {}",
+                        memberId, invitationId, request.accept());
 
         Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_FOUND));
+                        .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_FOUND));
 
         TeamInvitation invitation = teamInvitationRepository
-                .findByIdAndInvitee(invitationId, member)
-                .orElseThrow(() -> new BaseException(BaseResponseStatus.TEAM_INVITATION_NOT_FOUND));
+                        .findByIdAndInvitee(invitationId, member)
+                        .orElseThrow(() -> new BaseException(BaseResponseStatus.TEAM_INVITATION_NOT_FOUND));
 
         // 만료 확인 및 처리
         invitation.expireIfNeeded();
 
         if (!invitation.canBeProcessed()) {
-            throw new BaseException(invitation.isExpired() 
-                    ? BaseResponseStatus.TEAM_INVITATION_EXPIRED 
-                    : BaseResponseStatus.TEAM_INVITATION_NOT_PENDING);
+            throw new BaseException(invitation.isExpired()
+                            ? BaseResponseStatus.TEAM_INVITATION_EXPIRED
+                            : BaseResponseStatus.TEAM_INVITATION_NOT_PENDING);
         }
 
         String responseMessage;
         if (request.accept()) {
-            // 수락 처리
+            // 1. 초대 수락 처리
             invitation.accept();
-            
-            // 팀에 멤버 추가
+            teamInvitationRepository.save(invitation);
+
+            // 2. ✅ TeamMemberRepository로 직접 저장 (컬렉션 조작 X)
             Team team = invitation.getTeam();
             TeamMember newMember = TeamMember.of(team, member);
-            team.getTeamMembers().add(newMember);
+            teamMemberRepository.save(newMember);  // 직접 저장!
 
-            // 팀이 완성되었는지 확인하고 활성화
+            // 3. 팀이 완성되었는지 확인하고 활성화
             checkAndActivateTeam(team);
-            
+
             responseMessage = "팀 초대를 수락했습니다.";
+            log.info("팀 멤버 추가 완료 - teamId: {}, memberId: {}", team.getId(), member.getId());
+
         } else {
             // 거절 처리
             invitation.reject();
+            teamInvitationRepository.save(invitation);
             responseMessage = "팀 초대를 거절했습니다.";
         }
 
-        log.info("초대 응답 완료 - invitationId: {}, status: {}", 
-                invitation.getId(), invitation.getStatus());
+        log.info("초대 응답 완료 - invitationId: {}, status: {}",
+                        invitation.getId(), invitation.getStatus());
 
         return TeamResponseDto.RespondToInvitationResponse.builder()
-                .invitationId(invitation.getId())
-                .status(invitation.getStatus())
-                .message(responseMessage)
-                .build();
+                        .invitationId(invitation.getId())
+                        .status(invitation.getStatus())
+                        .message(responseMessage)
+                        .build();
     }
 
     /**
-     * 팀 활성화 확인 및 처리
+     * 팀 활성화 확인 및 처리 - 디버깅 버전
      */
     private void checkAndActivateTeam(Team team) {
-        // 모든 초대가 수락되었고, 팀원 수가 목표에 도달했는지 확인
-        boolean allInvitationsAccepted = teamInvitationRepository.areAllInvitationsAccepted(team);
-        boolean teamSizeReached = team.getCurrentMemberCount() == team.getTeamSize().getSize();
+        log.info("=== 팀 활성화 체크 시작 - teamId: {} ===", team.getId());
 
-        if (allInvitationsAccepted && teamSizeReached) {
+        // 1. 모든 초대가 수락되었는지 확인
+        boolean allInvitationsAccepted = teamInvitationRepository.areAllInvitationsAccepted(team);
+        log.info("모든 초대 수락 여부: {}", allInvitationsAccepted);
+
+        // 2. 현재 멤버 수 조회
+        long currentMemberCount = teamMemberRepository.countByTeam(team);
+        long targetMemberCount = team.getTeamSize().getSize();
+        log.info("현재 멤버 수: {} / 목표 멤버 수: {}", currentMemberCount, targetMemberCount);
+
+        // 3. 팀 현재 상태 확인
+        log.info("팀 현재 오픈 상태: {}", team.getIsOpen());
+
+        // 4. 각 조건별 체크
+        log.info("조건1 - 모든 초대 수락: {}", allInvitationsAccepted);
+        log.info("조건2 - 멤버 수 일치: {} == {} = {}", currentMemberCount, targetMemberCount, currentMemberCount == targetMemberCount);
+        log.info("조건3 - 아직 비활성: {}", !team.getIsOpen());
+
+        if (allInvitationsAccepted && currentMemberCount == targetMemberCount && !team.getIsOpen()) {
+            log.info("🎉 모든 조건 만족! 팀 활성화 실행!");
             team.activate();
-            log.info("팀 활성화 - teamId: {}, memberCount: {}", 
-                    team.getId(), team.getCurrentMemberCount());
+            teamRepository.save(team);
+
+            log.info("🎉 팀 활성화 완료! - teamId: {}, memberCount: {}/{}",
+                            team.getId(), currentMemberCount, targetMemberCount);
+        } else {
+            log.warn("❌ 팀 활성화 조건 미달성 - teamId: {}", team.getId());
+
+            // 상세한 미달성 이유 출력
+            if (!allInvitationsAccepted) {
+                log.warn("  - 이유: 아직 수락되지 않은 초대가 있음");
+            }
+            if (currentMemberCount != targetMemberCount) {
+                log.warn("  - 이유: 멤버 수 불일치 ({}/{})", currentMemberCount, targetMemberCount);
+            }
+            if (team.getIsOpen()) {
+                log.warn("  - 이유: 이미 활성화된 팀");
+            }
         }
+
+        log.info("=== 팀 활성화 체크 종료 ===");
     }
 
     /**
@@ -122,10 +162,11 @@ public class TeamInvitationService {
     @Transactional
     public void expireOldInvitations() {
         List<TeamInvitation> expiredInvitations = teamInvitationRepository
-                .findExpiredPendingInvitations(LocalDateTime.now());
+                        .findExpiredPendingInvitations(LocalDateTime.now());
 
         expiredInvitations.forEach(TeamInvitation::expireIfNeeded);
-        
+        teamInvitationRepository.saveAll(expiredInvitations);  // ✅ 일괄 저장 추가
+
         log.info("만료된 초대 정리 완료 - count: {}", expiredInvitations.size());
     }
 
@@ -137,32 +178,32 @@ public class TeamInvitationService {
         Member inviter = invitation.getInviter();
 
         return TeamResponseDto.TeamInvitationDetailResponse.builder()
-                .invitationId(invitation.getId())
-                .teamInfo(TeamResponseDto.TeamInfo.builder()
-                        .teamId(team.getId())
-                        .title(team.getTitle())
-                        .description(team.getDescription())
-                        .teamSize(team.getTeamSize())
-                        .preferredMood(team.getPreferredMood())
-                        .preferredAgeMin(team.getPreferredAgeMin().intValue())
-                        .preferredAgeMax(team.getPreferredAgeMax().intValue())
-                        .preferredEntryYearMin(team.getPreferredEntryYearMin().intValue())
-                        .preferredEntryYearMax(team.getPreferredEntryYearMax().intValue())
-                        .currentMemberCount(team.getCurrentMemberCount())
-                        .targetMemberCount(team.getTeamSize().getSize())
-                        .build())
-                .inviterInfo(TeamResponseDto.MemberInfo.builder()
-                        .memberId(inviter.getId())
-                        .nickname(inviter.getNickname())
-                        .age(inviter.getAge())
-                        .bio(inviter.getBio())
-                        .universityName(inviter.getUniversity().getName())
-                        .collegeName(inviter.getCollege() != null ? inviter.getCollege().getName() : null)
-                        .build())
-                .status(invitation.getStatus())
-                .createdAt(invitation.getCreatedAt())
-                .expiredAt(invitation.getExpiredAt())
-                .isExpired(invitation.isExpired())
-                .build();
+                        .invitationId(invitation.getId())
+                        .teamInfo(TeamResponseDto.TeamInfo.builder()
+                                        .teamId(team.getId())
+                                        .title(team.getTitle())
+                                        .description(team.getDescription())
+                                        .teamSize(team.getTeamSize())
+                                        .preferredMood(team.getPreferredMood())
+                                        .preferredAgeMin(team.getPreferredAgeMin().intValue())
+                                        .preferredAgeMax(team.getPreferredAgeMax().intValue())
+                                        .preferredEntryYearMin(team.getPreferredEntryYearMin().intValue())
+                                        .preferredEntryYearMax(team.getPreferredEntryYearMax().intValue())
+                                        .currentMemberCount(team.getCurrentMemberCount())
+                                        .targetMemberCount(team.getTeamSize().getSize())
+                                        .build())
+                        .inviterInfo(TeamResponseDto.MemberInfo.builder()
+                                        .memberId(inviter.getId())
+                                        .nickname(inviter.getNickname())
+                                        .age(inviter.getAge())
+                                        .bio(inviter.getBio())
+                                        .universityName(inviter.getUniversity().getName())
+                                        .collegeName(inviter.getCollege() != null ? inviter.getCollege().getName() : null)
+                                        .build())
+                        .status(invitation.getStatus())
+                        .createdAt(invitation.getCreatedAt())
+                        .expiredAt(invitation.getExpiredAt())
+                        .isExpired(invitation.isExpired())
+                        .build();
     }
 }

--- a/src/main/java/com/mini/buting/api/team/service/TeamInvitationService.java
+++ b/src/main/java/com/mini/buting/api/team/service/TeamInvitationService.java
@@ -1,0 +1,168 @@
+package com.mini.buting.api.team.service;
+
+import com.mini.buting.api.member.domain.Member;
+import com.mini.buting.api.member.repository.MemberRepository;
+import com.mini.buting.api.team.domain.Team;
+import com.mini.buting.api.team.domain.TeamInvitation;
+import com.mini.buting.api.team.domain.TeamMember;
+import com.mini.buting.api.team.dto.request.TeamRequestDto;
+import com.mini.buting.api.team.dto.response.TeamResponseDto;
+import com.mini.buting.api.team.repository.TeamInvitationRepository;
+import com.mini.buting.api.team.repository.TeamRepository;
+import com.mini.buting.global.exception.BaseException;
+import com.mini.buting.global.response.BaseResponseStatus;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+@Transactional(readOnly = true)
+public class TeamInvitationService {
+
+    private final TeamInvitationRepository teamInvitationRepository;
+    private final MemberRepository memberRepository;
+
+    /**
+     * 받은 초대 목록 조회
+     */
+    public List<TeamResponseDto.TeamInvitationDetailResponse> getReceivedInvitations(Long memberId) {
+        log.info("받은 초대 목록 조회 - memberId: {}", memberId);
+
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_FOUND));
+
+        List<TeamInvitation> invitations = teamInvitationRepository
+                .findPendingInvitationsByInvitee(member, LocalDateTime.now());
+
+        return invitations.stream()
+                .map(this::convertToDetailResponse)
+                .toList();
+    }
+
+    /**
+     * 초대 응답 (수락/거절)
+     */
+    @Transactional
+    public TeamResponseDto.RespondToInvitationResponse respondToInvitation(
+            Long memberId, Long invitationId, TeamRequestDto.RespondToInvitationRequest request) {
+
+        log.info("초대 응답 - memberId: {}, invitationId: {}, accept: {}", 
+                memberId, invitationId, request.accept());
+
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_FOUND));
+
+        TeamInvitation invitation = teamInvitationRepository
+                .findByIdAndInvitee(invitationId, member)
+                .orElseThrow(() -> new BaseException(BaseResponseStatus.TEAM_INVITATION_NOT_FOUND));
+
+        // 만료 확인 및 처리
+        invitation.expireIfNeeded();
+
+        if (!invitation.canBeProcessed()) {
+            throw new BaseException(invitation.isExpired() 
+                    ? BaseResponseStatus.TEAM_INVITATION_EXPIRED 
+                    : BaseResponseStatus.TEAM_INVITATION_NOT_PENDING);
+        }
+
+        String responseMessage;
+        if (request.accept()) {
+            // 수락 처리
+            invitation.accept();
+            
+            // 팀에 멤버 추가
+            Team team = invitation.getTeam();
+            TeamMember newMember = TeamMember.of(team, member);
+            team.getTeamMembers().add(newMember);
+
+            // 팀이 완성되었는지 확인하고 활성화
+            checkAndActivateTeam(team);
+            
+            responseMessage = "팀 초대를 수락했습니다.";
+        } else {
+            // 거절 처리
+            invitation.reject();
+            responseMessage = "팀 초대를 거절했습니다.";
+        }
+
+        log.info("초대 응답 완료 - invitationId: {}, status: {}", 
+                invitation.getId(), invitation.getStatus());
+
+        return TeamResponseDto.RespondToInvitationResponse.builder()
+                .invitationId(invitation.getId())
+                .status(invitation.getStatus())
+                .message(responseMessage)
+                .build();
+    }
+
+    /**
+     * 팀 활성화 확인 및 처리
+     */
+    private void checkAndActivateTeam(Team team) {
+        // 모든 초대가 수락되었고, 팀원 수가 목표에 도달했는지 확인
+        boolean allInvitationsAccepted = teamInvitationRepository.areAllInvitationsAccepted(team);
+        boolean teamSizeReached = team.getCurrentMemberCount() == team.getTeamSize().getSize();
+
+        if (allInvitationsAccepted && teamSizeReached) {
+            team.activate();
+            log.info("팀 활성화 - teamId: {}, memberCount: {}", 
+                    team.getId(), team.getCurrentMemberCount());
+        }
+    }
+
+    /**
+     * 만료된 초대들 정리 (배치 작업용)
+     */
+    @Transactional
+    public void expireOldInvitations() {
+        List<TeamInvitation> expiredInvitations = teamInvitationRepository
+                .findExpiredPendingInvitations(LocalDateTime.now());
+
+        expiredInvitations.forEach(TeamInvitation::expireIfNeeded);
+        
+        log.info("만료된 초대 정리 완료 - count: {}", expiredInvitations.size());
+    }
+
+    /**
+     * 초대 상세 응답 변환
+     */
+    private TeamResponseDto.TeamInvitationDetailResponse convertToDetailResponse(TeamInvitation invitation) {
+        Team team = invitation.getTeam();
+        Member inviter = invitation.getInviter();
+
+        return TeamResponseDto.TeamInvitationDetailResponse.builder()
+                .invitationId(invitation.getId())
+                .teamInfo(TeamResponseDto.TeamInfo.builder()
+                        .teamId(team.getId())
+                        .title(team.getTitle())
+                        .description(team.getDescription())
+                        .teamSize(team.getTeamSize())
+                        .preferredMood(team.getPreferredMood())
+                        .preferredAgeMin(team.getPreferredAgeMin().intValue())
+                        .preferredAgeMax(team.getPreferredAgeMax().intValue())
+                        .preferredEntryYearMin(team.getPreferredEntryYearMin().intValue())
+                        .preferredEntryYearMax(team.getPreferredEntryYearMax().intValue())
+                        .currentMemberCount(team.getCurrentMemberCount())
+                        .targetMemberCount(team.getTeamSize().getSize())
+                        .build())
+                .inviterInfo(TeamResponseDto.MemberInfo.builder()
+                        .memberId(inviter.getId())
+                        .nickname(inviter.getNickname())
+                        .age(inviter.getAge())
+                        .bio(inviter.getBio())
+                        .universityName(inviter.getUniversity().getName())
+                        .collegeName(inviter.getCollege() != null ? inviter.getCollege().getName() : null)
+                        .build())
+                .status(invitation.getStatus())
+                .createdAt(invitation.getCreatedAt())
+                .expiredAt(invitation.getExpiredAt())
+                .isExpired(invitation.isExpired())
+                .build();
+    }
+}

--- a/src/main/java/com/mini/buting/api/team/service/TeamInvitationService.java
+++ b/src/main/java/com/mini/buting/api/team/service/TeamInvitationService.java
@@ -9,7 +9,7 @@ import com.mini.buting.api.team.dto.request.TeamRequestDto;
 import com.mini.buting.api.team.dto.response.TeamResponseDto;
 import com.mini.buting.api.team.repository.TeamInvitationRepository;
 import com.mini.buting.api.team.repository.TeamMemberRepository;
-import com.mini.buting.api.team.repository.TeamRepository;  // ✅ 추가
+import com.mini.buting.api.team.repository.TeamRepository;
 import com.mini.buting.global.exception.BaseException;
 import com.mini.buting.global.response.BaseResponseStatus;
 import lombok.RequiredArgsConstructor;
@@ -28,50 +28,51 @@ public class TeamInvitationService {
 
     private final TeamInvitationRepository teamInvitationRepository;
     private final MemberRepository memberRepository;
-    private final TeamRepository teamRepository;  // ✅ 추가
+    private final TeamRepository teamRepository;
     private final TeamMemberRepository teamMemberRepository;
 
     /**
      * 받은 초대 목록 조회
      */
-    public List<TeamResponseDto.TeamInvitationDetailResponse> getReceivedInvitations(Long memberId) {
-        log.info("받은 초대 목록 조회 - memberId: {}", memberId);
+    public List<TeamResponseDto.TeamInvitationDetailResponse> getReceivedInvitations(
+                    Long memberId) {
+        log.debug("받은 초대 목록 조회 - memberId: {}", memberId);
 
         Member member = memberRepository.findById(memberId)
-                        .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_FOUND));
+                        .orElseThrow(() -> new BaseException(BaseResponseStatus.MEMBER_NOT_FOUND));
 
-        List<TeamInvitation> invitations = teamInvitationRepository
-                        .findPendingInvitationsByInvitee(member, LocalDateTime.now());
+        List<TeamInvitation> invitations =
+                        teamInvitationRepository.findPendingInvitationsByInvitee(member,
+                                        LocalDateTime.now());
 
-        return invitations.stream()
-                        .map(this::convertToDetailResponse)
-                        .toList();
+        return invitations.stream().map(this::convertToDetailResponse).toList();
     }
 
     /**
      * 초대 응답 (수락/거절) - 완전 수정 버전
      */
     @Transactional
-    public TeamResponseDto.RespondToInvitationResponse respondToInvitation(
-                    Long memberId, Long invitationId, TeamRequestDto.RespondToInvitationRequest request) {
+    public TeamResponseDto.RespondToInvitationResponse respondToInvitation(Long memberId,
+                    Long invitationId, TeamRequestDto.RespondToInvitationRequest request) {
 
-        log.info("초대 응답 - memberId: {}, invitationId: {}, accept: {}",
-                        memberId, invitationId, request.accept());
+        log.debug("초대 응답 - memberId: {}, invitationId: {}, accept: {}", memberId, invitationId,
+                        request.accept());
 
         Member member = memberRepository.findById(memberId)
-                        .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_FOUND));
+                        .orElseThrow(() -> new BaseException(BaseResponseStatus.MEMBER_NOT_FOUND));
 
-        TeamInvitation invitation = teamInvitationRepository
-                        .findByIdAndInvitee(invitationId, member)
-                        .orElseThrow(() -> new BaseException(BaseResponseStatus.TEAM_INVITATION_NOT_FOUND));
+        TeamInvitation invitation =
+                        teamInvitationRepository.findByIdAndInvitee(invitationId, member)
+                                        .orElseThrow(() -> new BaseException(
+                                                        BaseResponseStatus.TEAM_INVITATION_NOT_FOUND));
 
         // 만료 확인 및 처리
         invitation.expireIfNeeded();
 
         if (!invitation.canBeProcessed()) {
-            throw new BaseException(invitation.isExpired()
-                            ? BaseResponseStatus.TEAM_INVITATION_EXPIRED
-                            : BaseResponseStatus.TEAM_INVITATION_NOT_PENDING);
+            throw new BaseException(invitation.isExpired() ?
+                            BaseResponseStatus.TEAM_INVITATION_EXPIRED :
+                            BaseResponseStatus.TEAM_INVITATION_NOT_PENDING);
         }
 
         String responseMessage;
@@ -80,7 +81,7 @@ public class TeamInvitationService {
             invitation.accept();
             teamInvitationRepository.save(invitation);
 
-            // 2. ✅ TeamMemberRepository로 직접 저장 (컬렉션 조작 X)
+            // 2. TeamMemberRepository로 직접 저장 (컬렉션 조작 X)
             Team team = invitation.getTeam();
             TeamMember newMember = TeamMember.of(team, member);
             teamMemberRepository.save(newMember);  // 직접 저장!
@@ -89,7 +90,7 @@ public class TeamInvitationService {
             checkAndActivateTeam(team);
 
             responseMessage = "팀 초대를 수락했습니다.";
-            log.info("팀 멤버 추가 완료 - teamId: {}, memberId: {}", team.getId(), member.getId());
+            log.debug("팀 멤버 추가 완료 - teamId: {}, memberId: {}", team.getId(), member.getId());
 
         } else {
             // 거절 처리
@@ -98,62 +99,61 @@ public class TeamInvitationService {
             responseMessage = "팀 초대를 거절했습니다.";
         }
 
-        log.info("초대 응답 완료 - invitationId: {}, status: {}",
-                        invitation.getId(), invitation.getStatus());
+        log.debug("초대 응답 완료 - invitationId: {}, status: {}", invitation.getId(),
+                        invitation.getStatus());
 
         return TeamResponseDto.RespondToInvitationResponse.builder()
-                        .invitationId(invitation.getId())
-                        .status(invitation.getStatus())
-                        .message(responseMessage)
-                        .build();
+                        .invitationId(invitation.getId()).status(invitation.getStatus())
+                        .message(responseMessage).build();
     }
 
     /**
      * 팀 활성화 확인 및 처리 - 디버깅 버전
      */
     private void checkAndActivateTeam(Team team) {
-        log.info("=== 팀 활성화 체크 시작 - teamId: {} ===", team.getId());
+        log.debug("=== 팀 활성화 체크 시작 - teamId: {} ===", team.getId());
 
         // 1. 모든 초대가 수락되었는지 확인
         boolean allInvitationsAccepted = teamInvitationRepository.areAllInvitationsAccepted(team);
-        log.info("모든 초대 수락 여부: {}", allInvitationsAccepted);
+        log.debug("모든 초대 수락 여부: {}", allInvitationsAccepted);
 
         // 2. 현재 멤버 수 조회
         long currentMemberCount = teamMemberRepository.countByTeam(team);
         long targetMemberCount = team.getTeamSize().getSize();
-        log.info("현재 멤버 수: {} / 목표 멤버 수: {}", currentMemberCount, targetMemberCount);
+        log.debug("현재 멤버 수: {} / 목표 멤버 수: {}", currentMemberCount, targetMemberCount);
 
         // 3. 팀 현재 상태 확인
-        log.info("팀 현재 오픈 상태: {}", team.getIsOpen());
+        log.debug("팀 현재 오픈 상태: {}", team.getIsOpen());
 
         // 4. 각 조건별 체크
-        log.info("조건1 - 모든 초대 수락: {}", allInvitationsAccepted);
-        log.info("조건2 - 멤버 수 일치: {} == {} = {}", currentMemberCount, targetMemberCount, currentMemberCount == targetMemberCount);
-        log.info("조건3 - 아직 비활성: {}", !team.getIsOpen());
+        log.debug("조건1 - 모든 초대 수락: {}", allInvitationsAccepted);
+        log.debug("조건2 - 멤버 수 일치: {} == {} = {}", currentMemberCount, targetMemberCount,
+                        currentMemberCount == targetMemberCount);
+        log.debug("조건3 - 아직 비활성: {}", !team.getIsOpen());
 
         if (allInvitationsAccepted && currentMemberCount == targetMemberCount && !team.getIsOpen()) {
-            log.info("🎉 모든 조건 만족! 팀 활성화 실행!");
+            log.debug("모든 조건 만족, 팀 활성화 실행");
             team.activate();
             teamRepository.save(team);
 
-            log.info("🎉 팀 활성화 완료! - teamId: {}, memberCount: {}/{}",
-                            team.getId(), currentMemberCount, targetMemberCount);
+            log.debug("팀 활성화 완료! - teamId: {}, memberCount: {}/{}", team.getId(),
+                            currentMemberCount, targetMemberCount);
         } else {
-            log.warn("❌ 팀 활성화 조건 미달성 - teamId: {}", team.getId());
+            log.debug("팀 활성화 조건 미달성 - teamId: {}", team.getId());
 
             // 상세한 미달성 이유 출력
             if (!allInvitationsAccepted) {
-                log.warn("  - 이유: 아직 수락되지 않은 초대가 있음");
+                log.debug("  - 이유: 아직 수락되지 않은 초대가 있음");
             }
             if (currentMemberCount != targetMemberCount) {
-                log.warn("  - 이유: 멤버 수 불일치 ({}/{})", currentMemberCount, targetMemberCount);
+                log.debug("  - 이유: 멤버 수 불일치 ({}/{})", currentMemberCount, targetMemberCount);
             }
             if (team.getIsOpen()) {
-                log.warn("  - 이유: 이미 활성화된 팀");
+                log.debug("  - 이유: 이미 활성화된 팀");
             }
         }
 
-        log.info("=== 팀 활성화 체크 종료 ===");
+        log.debug("=== 팀 활성화 체크 종료 ===");
     }
 
     /**
@@ -161,49 +161,46 @@ public class TeamInvitationService {
      */
     @Transactional
     public void expireOldInvitations() {
-        List<TeamInvitation> expiredInvitations = teamInvitationRepository
-                        .findExpiredPendingInvitations(LocalDateTime.now());
+        List<TeamInvitation> expiredInvitations =
+                        teamInvitationRepository.findExpiredPendingInvitations(LocalDateTime.now());
 
         expiredInvitations.forEach(TeamInvitation::expireIfNeeded);
-        teamInvitationRepository.saveAll(expiredInvitations);  // ✅ 일괄 저장 추가
+        teamInvitationRepository.saveAll(expiredInvitations);
 
-        log.info("만료된 초대 정리 완료 - count: {}", expiredInvitations.size());
+        log.debug("만료된 초대 정리 완료 - count: {}", expiredInvitations.size());
     }
 
     /**
      * 초대 상세 응답 변환
      */
-    private TeamResponseDto.TeamInvitationDetailResponse convertToDetailResponse(TeamInvitation invitation) {
+    private TeamResponseDto.TeamInvitationDetailResponse convertToDetailResponse(
+                    TeamInvitation invitation) {
         Team team = invitation.getTeam();
         Member inviter = invitation.getInviter();
 
         return TeamResponseDto.TeamInvitationDetailResponse.builder()
                         .invitationId(invitation.getId())
-                        .teamInfo(TeamResponseDto.TeamInfo.builder()
-                                        .teamId(team.getId())
-                                        .title(team.getTitle())
-                                        .description(team.getDescription())
+                        .teamInfo(TeamResponseDto.TeamInfo.builder().teamId(team.getId())
+                                        .title(team.getTitle()).description(team.getDescription())
                                         .teamSize(team.getTeamSize())
                                         .preferredMood(team.getPreferredMood())
                                         .preferredAgeMin(team.getPreferredAgeMin().intValue())
                                         .preferredAgeMax(team.getPreferredAgeMax().intValue())
-                                        .preferredEntryYearMin(team.getPreferredEntryYearMin().intValue())
-                                        .preferredEntryYearMax(team.getPreferredEntryYearMax().intValue())
+                                        .preferredEntryYearMin(
+                                                        team.getPreferredEntryYearMin().intValue())
+                                        .preferredEntryYearMax(
+                                                        team.getPreferredEntryYearMax().intValue())
                                         .currentMemberCount(team.getCurrentMemberCount())
-                                        .targetMemberCount(team.getTeamSize().getSize())
-                                        .build())
-                        .inviterInfo(TeamResponseDto.MemberInfo.builder()
-                                        .memberId(inviter.getId())
-                                        .nickname(inviter.getNickname())
-                                        .age(inviter.getAge())
+                                        .targetMemberCount(team.getTeamSize().getSize()).build())
+                        .inviterInfo(TeamResponseDto.MemberInfo.builder().memberId(inviter.getId())
+                                        .nickname(inviter.getNickname()).age(inviter.getAge())
                                         .bio(inviter.getBio())
                                         .universityName(inviter.getUniversity().getName())
-                                        .collegeName(inviter.getCollege() != null ? inviter.getCollege().getName() : null)
-                                        .build())
-                        .status(invitation.getStatus())
-                        .createdAt(invitation.getCreatedAt())
-                        .expiredAt(invitation.getExpiredAt())
-                        .isExpired(invitation.isExpired())
+                                        .collegeName(inviter.getCollege() != null ?
+                                                        inviter.getCollege().getName() :
+                                                        null).build())
+                        .status(invitation.getStatus()).createdAt(invitation.getCreatedAt())
+                        .expiredAt(invitation.getExpiredAt()).isExpired(invitation.isExpired())
                         .build();
     }
 }

--- a/src/main/java/com/mini/buting/api/team/service/TeamService.java
+++ b/src/main/java/com/mini/buting/api/team/service/TeamService.java
@@ -11,6 +11,7 @@ import com.mini.buting.api.team.domain.TeamMember;
 import com.mini.buting.api.team.dto.request.TeamRequestDto;
 import com.mini.buting.api.team.dto.response.TeamResponseDto;
 import com.mini.buting.api.team.repository.TeamInvitationRepository;
+import com.mini.buting.api.team.repository.TeamMemberRepository;
 import com.mini.buting.api.team.repository.TeamRepository;
 import com.mini.buting.global.exception.BaseException;
 import com.mini.buting.global.response.BaseResponseStatus;
@@ -32,18 +33,19 @@ public class TeamService {
     private final TeamInvitationRepository teamInvitationRepository;
     private final MemberRepository memberRepository;
     private final FriendRepository friendRepository;
+    private final TeamMemberRepository teamMemberRepository;
 
     /**
      * 팀 생성
      */
     @Transactional
     public TeamResponseDto.CreateTeamResponse createTeam(Long leaderId, TeamRequestDto.CreateTeamRequest request) {
-        log.info("팀 생성 요청 - leaderId: {}, teamSize: {}, inviteCount: {}", 
-                leaderId, request.teamSize(), request.inviteMemberIds().size());
+        log.info("팀 생성 요청 - leaderId: {}, teamSize: {}, inviteCount: {}",
+                        leaderId, request.teamSize(), request.inviteMemberIds().size());
 
         // 1. 팀장 조회
         Member leader = memberRepository.findById(leaderId)
-                .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_FOUND));
+                        .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_FOUND));
 
         // 2. 팀장이 이미 다른 팀의 리더인지 확인
         if (teamRepository.existsByLeader(leader)) {
@@ -55,33 +57,34 @@ public class TeamService {
 
         // 4. 팀 생성
         Team team = Team.builder()
-                .title(request.title())
-                .description(request.description())
-                .preferredMood(request.preferredMood())
-                .teamSize(request.teamSize())
-                .preferredAgeMin(request.preferredAgeMin().byteValue())
-                .preferredAgeMax(request.preferredAgeMax().byteValue())
-                .preferredEntryYearMin(request.preferredEntryYearMin().byteValue())
-                .preferredEntryYearMax(request.preferredEntryYearMax().byteValue())
-                .gender(Gender.fromMemberGender(leader.getGender()))
-                .leader(leader)
-                .isOpen(false) // 모든 멤버가 수락해야 true
-                .build();
+                        .title(request.title())
+                        .description(request.description())
+                        .preferredMood(request.preferredMood())
+                        .teamSize(request.teamSize())
+                        .preferredAgeMin(request.preferredAgeMin().byteValue())
+                        .preferredAgeMax(request.preferredAgeMax().byteValue())
+                        .preferredEntryYearMin(request.preferredEntryYearMin().byteValue())
+                        .preferredEntryYearMax(request.preferredEntryYearMax().byteValue())
+                        .gender(Gender.fromMemberGender(leader.getGender()))
+                        .leader(leader)
+                        .isOpen(false) // 모든 멤버가 수락해야 true
+                        .build();
 
         Team savedTeam = teamRepository.save(team);
 
-        // 5. 팀장을 팀 멤버로 추가
+        // ✅ 5. 팀장을 팀 멤버로 추가 - 직접 저장
         TeamMember leaderMember = TeamMember.of(savedTeam, leader);
-        savedTeam.getTeamMembers().add(leaderMember);
+        teamMemberRepository.save(leaderMember);  // 직접 저장!
+        log.info("팀장 멤버 추가 완료 - teamId: {}, leaderId: {}", savedTeam.getId(), leader.getId());
 
         // 6. 초대 생성
         List<TeamInvitation> invitations = invitees.stream()
-                .map(invitee -> TeamInvitation.builder()
-                        .team(savedTeam)
-                        .inviter(leader)
-                        .invitee(invitee)
-                        .build())
-                .collect(Collectors.toList());
+                        .map(invitee -> TeamInvitation.builder()
+                                        .team(savedTeam)
+                                        .inviter(leader)
+                                        .invitee(invitee)
+                                        .build())
+                        .collect(Collectors.toList());
 
         List<TeamInvitation> savedInvitations = teamInvitationRepository.saveAll(invitations);
 
@@ -89,28 +92,28 @@ public class TeamService {
 
         // 7. 응답 생성
         return TeamResponseDto.CreateTeamResponse.builder()
-                .teamId(savedTeam.getId())
-                .title(savedTeam.getTitle())
-                .description(savedTeam.getDescription())
-                .teamSize(savedTeam.getTeamSize())
-                .preferredMood(savedTeam.getPreferredMood())
-                .preferredAgeMin(savedTeam.getPreferredAgeMin().intValue())
-                .preferredAgeMax(savedTeam.getPreferredAgeMax().intValue())
-                .preferredEntryYearMin(savedTeam.getPreferredEntryYearMin().intValue())
-                .preferredEntryYearMax(savedTeam.getPreferredEntryYearMax().intValue())
-                .isOpen(savedTeam.getIsOpen())
-                .sentInvitations(convertToInvitationInfos(savedInvitations))
-                .build();
+                        .teamId(savedTeam.getId())
+                        .title(savedTeam.getTitle())
+                        .description(savedTeam.getDescription())
+                        .teamSize(savedTeam.getTeamSize())
+                        .preferredMood(savedTeam.getPreferredMood())
+                        .preferredAgeMin(savedTeam.getPreferredAgeMin().intValue())
+                        .preferredAgeMax(savedTeam.getPreferredAgeMax().intValue())
+                        .preferredEntryYearMin(savedTeam.getPreferredEntryYearMin().intValue())
+                        .preferredEntryYearMax(savedTeam.getPreferredEntryYearMax().intValue())
+                        .isOpen(savedTeam.getIsOpen())
+                        .sentInvitations(convertToInvitationInfos(savedInvitations))
+                        .build();
     }
 
     /**
-     * 친구 검색 (팀 초대용)
+     * 친구 검색 (팀 초대용) - 같은 성별만 필터링
      */
     public TeamResponseDto.SearchFriendsResponse searchFriends(Long memberId, TeamRequestDto.SearchFriendsRequest request) {
         log.info("친구 검색 요청 - memberId: {}, keyword: {}", memberId, request.keyword());
 
         Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_FOUND));
+                        .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_FOUND));
 
         List<Friend> friends;
         if (request.keyword() == null || request.keyword().trim().isEmpty()) {
@@ -119,27 +122,107 @@ public class TeamService {
             friends = friendRepository.findFriendsByMemberAndKeyword(member, request.keyword().trim());
         }
 
+        // ✅ 수정: 같은 성별만 필터링
         List<TeamResponseDto.SearchableFriend> searchableFriends = friends.stream()
-                .map(friend -> {
-                    Member friendMember = friend.getOtherMember(member);
-                    return TeamResponseDto.SearchableFriend.builder()
-                            .memberId(friendMember.getId())
-                            .nickname(friendMember.getNickname())
-                            .universityEmail(friendMember.getFullUniversityEmail())
-                            .bio(friendMember.getBio())
-                            .age(friendMember.getAge())
-                            .genderDisplayName(friendMember.getGender().getDescription())
-                            .universityName(friendMember.getUniversity().getName())
-                            .collegeName(friendMember.getCollege() != null ? friendMember.getCollege().getName() : null)
-                            .personalityTypes(friendMember.getPersonalityCodes())
-                            .build();
-                })
-                .toList();
+                        .map(friend -> friend.getOtherMember(member))
+                        .filter(friendMember -> friendMember.getGender() == member.getGender()) // 같은 성별 필터링
+                        .map(friendMember -> TeamResponseDto.SearchableFriend.builder()
+                                        .memberId(friendMember.getId())
+                                        .nickname(friendMember.getNickname())
+                                        .universityEmail(friendMember.getFullUniversityEmail())
+                                        .bio(friendMember.getBio())
+                                        .age(friendMember.getAge())
+                                        .genderDisplayName(friendMember.getGender().getDescription())
+                                        .universityName(friendMember.getUniversity().getName())
+                                        .collegeName(friendMember.getCollege() != null ? friendMember.getCollege().getName() : null)
+                                        .personalityTypes(friendMember.getPersonalityCodes())
+                                        .build())
+                        .toList();
 
         return TeamResponseDto.SearchFriendsResponse.builder()
-                .friends(searchableFriends)
-                .totalCount(searchableFriends.size())
-                .build();
+                        .friends(searchableFriends)
+                        .totalCount(searchableFriends.size())
+                        .build();
+    }
+
+    /**
+     * 초대 응답 (수락/거절) - 완전 수정 버전
+     */
+    @Transactional
+    public TeamResponseDto.RespondToInvitationResponse respondToInvitation(
+                    Long memberId, Long invitationId, TeamRequestDto.RespondToInvitationRequest request) {
+
+        log.info("초대 응답 - memberId: {}, invitationId: {}, accept: {}",
+                        memberId, invitationId, request.accept());
+
+        Member member = memberRepository.findById(memberId)
+                        .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_FOUND));
+
+        TeamInvitation invitation = teamInvitationRepository
+                        .findByIdAndInvitee(invitationId, member)
+                        .orElseThrow(() -> new BaseException(BaseResponseStatus.TEAM_INVITATION_NOT_FOUND));
+
+        // 만료 확인 및 처리
+        invitation.expireIfNeeded();
+
+        if (!invitation.canBeProcessed()) {
+            throw new BaseException(invitation.isExpired()
+                            ? BaseResponseStatus.TEAM_INVITATION_EXPIRED
+                            : BaseResponseStatus.TEAM_INVITATION_NOT_PENDING);
+        }
+
+        String responseMessage;
+        if (request.accept()) {
+            // 수락 처리
+            invitation.accept();
+            teamInvitationRepository.save(invitation);
+
+            // ✅ TeamMemberRepository를 통한 안전한 저장
+            Team team = invitation.getTeam();
+
+            // 이미 팀 멤버인지 확인 (중복 방지)
+            if (!teamMemberRepository.existsByTeamAndMember(team, member)) {
+                TeamMember newMember = TeamMember.of(team, member);
+                teamMemberRepository.save(newMember);
+                log.debug("새 팀 멤버 추가 - teamId: {}, memberId: {}", team.getId(), member.getId());
+            }
+
+            // 팀이 완성되었는지 확인하고 활성화
+            checkAndOpenTeam(team);
+
+            responseMessage = "팀 초대를 수락했습니다.";
+        } else {
+            // 거절 처리
+            invitation.reject();
+            teamInvitationRepository.save(invitation);
+            responseMessage = "팀 초대를 거절했습니다.";
+        }
+
+        log.info("초대 응답 완료 - invitationId: {}, status: {}",
+                        invitation.getId(), invitation.getStatus());
+
+        return TeamResponseDto.RespondToInvitationResponse.builder()
+                        .invitationId(invitation.getId())
+                        .status(invitation.getStatus())
+                        .message(responseMessage)
+                        .build();
+    }
+
+    /**
+     * ✅ 새로 추가: 모든 초대가 수락되었는지 확인하고 팀을 오픈 상태로 변경
+     */
+    @Transactional
+    public void checkAndOpenTeam(Team team) {
+        // 더 효율적으로 모든 초대가 수락되었는지 확인
+        boolean allAccepted = teamInvitationRepository.areAllInvitationsAccepted(team);
+
+        if (allAccepted && !team.getIsOpen()) {
+            // 팀을 오픈 상태로 변경
+            team.activate();
+            teamRepository.save(team);
+
+            log.info("팀 오픈 상태 변경 - teamId: {}, 모든 초대가 수락됨", team.getId());
+        }
     }
 
     /**
@@ -164,6 +247,13 @@ public class TeamService {
             }
         }
 
+        // 4. 모든 초대 대상이 같은 성별인지 확인
+        for (Member invitee : invitees) {
+            if (invitee.getGender() != leader.getGender()) {
+                throw new BaseException(BaseResponseStatus.DIFFERENT_GENDER_CANNOT_INVITE);
+            }
+        }
+
         return invitees;
     }
 
@@ -172,15 +262,15 @@ public class TeamService {
      */
     private List<TeamResponseDto.TeamInvitationInfo> convertToInvitationInfos(List<TeamInvitation> invitations) {
         return invitations.stream()
-                .map(invitation -> TeamResponseDto.TeamInvitationInfo.builder()
-                        .invitationId(invitation.getId())
-                        .inviteeId(invitation.getInvitee().getId())
-                        .inviteeName(invitation.getInvitee().getNickname())
-                        .inviteeNickname(invitation.getInvitee().getNickname())
-                        .status(invitation.getStatus())
-                        .createdAt(invitation.getCreatedAt())
-                        .expiredAt(invitation.getExpiredAt())
-                        .build())
-                .collect(Collectors.toList());
+                        .map(invitation -> TeamResponseDto.TeamInvitationInfo.builder()
+                                        .invitationId(invitation.getId())
+                                        .inviteeId(invitation.getInvitee().getId())
+                                        .inviteeName(invitation.getInvitee().getNickname())
+                                        .inviteeNickname(invitation.getInvitee().getNickname())
+                                        .status(invitation.getStatus())
+                                        .createdAt(invitation.getCreatedAt())
+                                        .expiredAt(invitation.getExpiredAt())
+                                        .build())
+                        .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/mini/buting/api/team/service/TeamService.java
+++ b/src/main/java/com/mini/buting/api/team/service/TeamService.java
@@ -1,0 +1,186 @@
+package com.mini.buting.api.team.service;
+
+import com.mini.buting.api.friend.domain.Friend;
+import com.mini.buting.api.friend.repository.FriendRepository;
+import com.mini.buting.api.member.domain.Member;
+import com.mini.buting.api.member.repository.MemberRepository;
+import com.mini.buting.api.team.domain.Gender;
+import com.mini.buting.api.team.domain.Team;
+import com.mini.buting.api.team.domain.TeamInvitation;
+import com.mini.buting.api.team.domain.TeamMember;
+import com.mini.buting.api.team.dto.request.TeamRequestDto;
+import com.mini.buting.api.team.dto.response.TeamResponseDto;
+import com.mini.buting.api.team.repository.TeamInvitationRepository;
+import com.mini.buting.api.team.repository.TeamRepository;
+import com.mini.buting.global.exception.BaseException;
+import com.mini.buting.global.response.BaseResponseStatus;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+@Transactional(readOnly = true)
+public class TeamService {
+
+    private final TeamRepository teamRepository;
+    private final TeamInvitationRepository teamInvitationRepository;
+    private final MemberRepository memberRepository;
+    private final FriendRepository friendRepository;
+
+    /**
+     * 팀 생성
+     */
+    @Transactional
+    public TeamResponseDto.CreateTeamResponse createTeam(Long leaderId, TeamRequestDto.CreateTeamRequest request) {
+        log.info("팀 생성 요청 - leaderId: {}, teamSize: {}, inviteCount: {}", 
+                leaderId, request.teamSize(), request.inviteMemberIds().size());
+
+        // 1. 팀장 조회
+        Member leader = memberRepository.findById(leaderId)
+                .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_FOUND));
+
+        // 2. 팀장이 이미 다른 팀의 리더인지 확인
+        if (teamRepository.existsByLeader(leader)) {
+            throw new BaseException(BaseResponseStatus.ALREADY_TEAM_LEADER);
+        }
+
+        // 3. 초대할 멤버들 조회 및 검증
+        List<Member> invitees = validateAndGetInvitees(leader, request.inviteMemberIds());
+
+        // 4. 팀 생성
+        Team team = Team.builder()
+                .title(request.title())
+                .description(request.description())
+                .preferredMood(request.preferredMood())
+                .teamSize(request.teamSize())
+                .preferredAgeMin(request.preferredAgeMin().byteValue())
+                .preferredAgeMax(request.preferredAgeMax().byteValue())
+                .preferredEntryYearMin(request.preferredEntryYearMin().byteValue())
+                .preferredEntryYearMax(request.preferredEntryYearMax().byteValue())
+                .gender(Gender.fromMemberGender(leader.getGender()))
+                .leader(leader)
+                .isOpen(false) // 모든 멤버가 수락해야 true
+                .build();
+
+        Team savedTeam = teamRepository.save(team);
+
+        // 5. 팀장을 팀 멤버로 추가
+        TeamMember leaderMember = TeamMember.of(savedTeam, leader);
+        savedTeam.getTeamMembers().add(leaderMember);
+
+        // 6. 초대 생성
+        List<TeamInvitation> invitations = invitees.stream()
+                .map(invitee -> TeamInvitation.builder()
+                        .team(savedTeam)
+                        .inviter(leader)
+                        .invitee(invitee)
+                        .build())
+                .collect(Collectors.toList());
+
+        List<TeamInvitation> savedInvitations = teamInvitationRepository.saveAll(invitations);
+
+        log.info("팀 생성 완료 - teamId: {}, invitationCount: {}", savedTeam.getId(), savedInvitations.size());
+
+        // 7. 응답 생성
+        return TeamResponseDto.CreateTeamResponse.builder()
+                .teamId(savedTeam.getId())
+                .title(savedTeam.getTitle())
+                .description(savedTeam.getDescription())
+                .teamSize(savedTeam.getTeamSize())
+                .preferredMood(savedTeam.getPreferredMood())
+                .preferredAgeMin(savedTeam.getPreferredAgeMin().intValue())
+                .preferredAgeMax(savedTeam.getPreferredAgeMax().intValue())
+                .preferredEntryYearMin(savedTeam.getPreferredEntryYearMin().intValue())
+                .preferredEntryYearMax(savedTeam.getPreferredEntryYearMax().intValue())
+                .isOpen(savedTeam.getIsOpen())
+                .sentInvitations(convertToInvitationInfos(savedInvitations))
+                .build();
+    }
+
+    /**
+     * 친구 검색 (팀 초대용)
+     */
+    public TeamResponseDto.SearchFriendsResponse searchFriends(Long memberId, TeamRequestDto.SearchFriendsRequest request) {
+        log.info("친구 검색 요청 - memberId: {}, keyword: {}", memberId, request.keyword());
+
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_FOUND));
+
+        List<Friend> friends;
+        if (request.keyword() == null || request.keyword().trim().isEmpty()) {
+            friends = friendRepository.findFriendsByMember(member);
+        } else {
+            friends = friendRepository.findFriendsByMemberAndKeyword(member, request.keyword().trim());
+        }
+
+        List<TeamResponseDto.SearchableFriend> searchableFriends = friends.stream()
+                .map(friend -> {
+                    Member friendMember = friend.getOtherMember(member);
+                    return TeamResponseDto.SearchableFriend.builder()
+                            .memberId(friendMember.getId())
+                            .nickname(friendMember.getNickname())
+                            .universityEmail(friendMember.getFullUniversityEmail())
+                            .bio(friendMember.getBio())
+                            .age(friendMember.getAge())
+                            .genderDisplayName(friendMember.getGender().getDescription())
+                            .universityName(friendMember.getUniversity().getName())
+                            .collegeName(friendMember.getCollege() != null ? friendMember.getCollege().getName() : null)
+                            .personalityTypes(friendMember.getPersonalityCodes())
+                            .build();
+                })
+                .toList();
+
+        return TeamResponseDto.SearchFriendsResponse.builder()
+                .friends(searchableFriends)
+                .totalCount(searchableFriends.size())
+                .build();
+    }
+
+    /**
+     * 초대할 멤버들 검증 및 조회
+     */
+    private List<Member> validateAndGetInvitees(Member leader, List<Long> inviteMemberIds) {
+        // 1. 자신을 초대하는지 확인
+        if (inviteMemberIds.contains(leader.getId())) {
+            throw new BaseException(BaseResponseStatus.CANNOT_INVITE_SELF);
+        }
+
+        // 2. 초대할 멤버들 조회
+        List<Member> invitees = memberRepository.findAllById(inviteMemberIds);
+        if (invitees.size() != inviteMemberIds.size()) {
+            throw new BaseException(BaseResponseStatus.NOT_FOUND);
+        }
+
+        // 3. 모든 초대 대상이 친구인지 확인
+        for (Member invitee : invitees) {
+            if (!friendRepository.existsFriendshipBetween(leader.getId(), invitee.getId())) {
+                throw new BaseException(BaseResponseStatus.NOT_FRIEND_CANNOT_INVITE);
+            }
+        }
+
+        return invitees;
+    }
+
+    /**
+     * 초대 정보 변환
+     */
+    private List<TeamResponseDto.TeamInvitationInfo> convertToInvitationInfos(List<TeamInvitation> invitations) {
+        return invitations.stream()
+                .map(invitation -> TeamResponseDto.TeamInvitationInfo.builder()
+                        .invitationId(invitation.getId())
+                        .inviteeId(invitation.getInvitee().getId())
+                        .inviteeName(invitation.getInvitee().getNickname())
+                        .inviteeNickname(invitation.getInvitee().getNickname())
+                        .status(invitation.getStatus())
+                        .createdAt(invitation.getCreatedAt())
+                        .expiredAt(invitation.getExpiredAt())
+                        .build())
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/mini/buting/api/team/service/TeamService.java
+++ b/src/main/java/com/mini/buting/api/team/service/TeamService.java
@@ -39,13 +39,14 @@ public class TeamService {
      * 팀 생성
      */
     @Transactional
-    public TeamResponseDto.CreateTeamResponse createTeam(Long leaderId, TeamRequestDto.CreateTeamRequest request) {
-        log.info("팀 생성 요청 - leaderId: {}, teamSize: {}, inviteCount: {}",
-                        leaderId, request.teamSize(), request.inviteMemberIds().size());
+    public TeamResponseDto.CreateTeamResponse createTeam(Long leaderId,
+                    TeamRequestDto.CreateTeamRequest request) {
+        log.debug("팀 생성 요청 - leaderId: {}, teamSize: {}, inviteCount: {}", leaderId,
+                        request.teamSize(), request.inviteMemberIds().size());
 
         // 1. 팀장 조회
         Member leader = memberRepository.findById(leaderId)
-                        .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_FOUND));
+                        .orElseThrow(() -> new BaseException(BaseResponseStatus.MEMBER_NOT_FOUND));
 
         // 2. 팀장이 이미 다른 팀의 리더인지 확인
         if (teamRepository.existsByLeader(leader)) {
@@ -56,45 +57,36 @@ public class TeamService {
         List<Member> invitees = validateAndGetInvitees(leader, request.inviteMemberIds());
 
         // 4. 팀 생성
-        Team team = Team.builder()
-                        .title(request.title())
-                        .description(request.description())
-                        .preferredMood(request.preferredMood())
-                        .teamSize(request.teamSize())
+        Team team = Team.builder().title(request.title()).description(request.description())
+                        .preferredMood(request.preferredMood()).teamSize(request.teamSize())
                         .preferredAgeMin(request.preferredAgeMin().byteValue())
                         .preferredAgeMax(request.preferredAgeMax().byteValue())
                         .preferredEntryYearMin(request.preferredEntryYearMin().byteValue())
                         .preferredEntryYearMax(request.preferredEntryYearMax().byteValue())
-                        .gender(Gender.fromMemberGender(leader.getGender()))
-                        .leader(leader)
+                        .gender(Gender.fromMemberGender(leader.getGender())).leader(leader)
                         .isOpen(false) // 모든 멤버가 수락해야 true
                         .build();
 
         Team savedTeam = teamRepository.save(team);
 
-        // ✅ 5. 팀장을 팀 멤버로 추가 - 직접 저장
+        // 5. 팀장을 팀 멤버로 추가 - 직접 저장
         TeamMember leaderMember = TeamMember.of(savedTeam, leader);
         teamMemberRepository.save(leaderMember);  // 직접 저장!
-        log.info("팀장 멤버 추가 완료 - teamId: {}, leaderId: {}", savedTeam.getId(), leader.getId());
+        log.debug("팀장 멤버 추가 완료 - teamId: {}, leaderId: {}", savedTeam.getId(), leader.getId());
 
         // 6. 초대 생성
         List<TeamInvitation> invitations = invitees.stream()
-                        .map(invitee -> TeamInvitation.builder()
-                                        .team(savedTeam)
-                                        .inviter(leader)
-                                        .invitee(invitee)
-                                        .build())
-                        .collect(Collectors.toList());
+                        .map(invitee -> TeamInvitation.builder().team(savedTeam).inviter(leader)
+                                        .invitee(invitee).build()).collect(Collectors.toList());
 
         List<TeamInvitation> savedInvitations = teamInvitationRepository.saveAll(invitations);
 
-        log.info("팀 생성 완료 - teamId: {}, invitationCount: {}", savedTeam.getId(), savedInvitations.size());
+        log.debug("팀 생성 완료 - teamId: {}, invitationCount: {}", savedTeam.getId(),
+                        savedInvitations.size());
 
         // 7. 응답 생성
-        return TeamResponseDto.CreateTeamResponse.builder()
-                        .teamId(savedTeam.getId())
-                        .title(savedTeam.getTitle())
-                        .description(savedTeam.getDescription())
+        return TeamResponseDto.CreateTeamResponse.builder().teamId(savedTeam.getId())
+                        .title(savedTeam.getTitle()).description(savedTeam.getDescription())
                         .teamSize(savedTeam.getTeamSize())
                         .preferredMood(savedTeam.getPreferredMood())
                         .preferredAgeMin(savedTeam.getPreferredAgeMin().intValue())
@@ -102,73 +94,78 @@ public class TeamService {
                         .preferredEntryYearMin(savedTeam.getPreferredEntryYearMin().intValue())
                         .preferredEntryYearMax(savedTeam.getPreferredEntryYearMax().intValue())
                         .isOpen(savedTeam.getIsOpen())
-                        .sentInvitations(convertToInvitationInfos(savedInvitations))
-                        .build();
+                        .sentInvitations(convertToInvitationInfos(savedInvitations)).build();
     }
 
     /**
      * 친구 검색 (팀 초대용) - 같은 성별만 필터링
      */
-    public TeamResponseDto.SearchFriendsResponse searchFriends(Long memberId, TeamRequestDto.SearchFriendsRequest request) {
-        log.info("친구 검색 요청 - memberId: {}, keyword: {}", memberId, request.keyword());
+    public TeamResponseDto.SearchFriendsResponse searchFriends(Long memberId,
+                    TeamRequestDto.SearchFriendsRequest request) {
+        log.debug("친구 검색 요청 - memberId: {}, keyword: {}", memberId, request.keyword());
 
         Member member = memberRepository.findById(memberId)
-                        .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_FOUND));
+                        .orElseThrow(() -> new BaseException(BaseResponseStatus.MEMBER_NOT_FOUND));
 
         List<Friend> friends;
         if (request.keyword() == null || request.keyword().trim().isEmpty()) {
             friends = friendRepository.findFriendsByMember(member);
         } else {
-            friends = friendRepository.findFriendsByMemberAndKeyword(member, request.keyword().trim());
+            friends = friendRepository.findFriendsByMemberAndKeyword(member,
+                            request.keyword().trim());
         }
 
-        // ✅ 수정: 같은 성별만 필터링
-        List<TeamResponseDto.SearchableFriend> searchableFriends = friends.stream()
-                        .map(friend -> friend.getOtherMember(member))
-                        .filter(friendMember -> friendMember.getGender() == member.getGender()) // 같은 성별 필터링
-                        .map(friendMember -> TeamResponseDto.SearchableFriend.builder()
-                                        .memberId(friendMember.getId())
-                                        .nickname(friendMember.getNickname())
-                                        .universityEmail(friendMember.getFullUniversityEmail())
-                                        .bio(friendMember.getBio())
-                                        .age(friendMember.getAge())
-                                        .genderDisplayName(friendMember.getGender().getDescription())
-                                        .universityName(friendMember.getUniversity().getName())
-                                        .collegeName(friendMember.getCollege() != null ? friendMember.getCollege().getName() : null)
-                                        .personalityTypes(friendMember.getPersonalityCodes())
-                                        .build())
-                        .toList();
+        // 수정: 같은 성별만 필터링
+        List<TeamResponseDto.SearchableFriend> searchableFriends =
+                        friends.stream().map(friend -> friend.getOtherMember(member))
+                                        .filter(friendMember -> friendMember.getGender() == member.getGender()) // 같은 성별 필터링
+                                        .map(friendMember -> TeamResponseDto.SearchableFriend.builder()
+                                                        .memberId(friendMember.getId())
+                                                        .nickname(friendMember.getNickname())
+                                                        .universityEmail(
+                                                                        friendMember.getFullUniversityEmail())
+                                                        .bio(friendMember.getBio())
+                                                        .age(friendMember.getAge())
+                                                        .genderDisplayName(friendMember.getGender()
+                                                                        .getDescription())
+                                                        .universityName(friendMember.getUniversity()
+                                                                        .getName())
+                                                        .collegeName(friendMember.getCollege() != null ?
+                                                                        friendMember.getCollege()
+                                                                                        .getName() :
+                                                                        null).personalityTypes(
+                                                                        friendMember.getPersonalityCodes())
+                                                        .build()).toList();
 
-        return TeamResponseDto.SearchFriendsResponse.builder()
-                        .friends(searchableFriends)
-                        .totalCount(searchableFriends.size())
-                        .build();
+        return TeamResponseDto.SearchFriendsResponse.builder().friends(searchableFriends)
+                        .totalCount(searchableFriends.size()).build();
     }
 
     /**
-     * 초대 응답 (수락/거절) - 완전 수정 버전
+     * 초대 응답 (수락/거절)
      */
     @Transactional
-    public TeamResponseDto.RespondToInvitationResponse respondToInvitation(
-                    Long memberId, Long invitationId, TeamRequestDto.RespondToInvitationRequest request) {
+    public TeamResponseDto.RespondToInvitationResponse respondToInvitation(Long memberId,
+                    Long invitationId, TeamRequestDto.RespondToInvitationRequest request) {
 
-        log.info("초대 응답 - memberId: {}, invitationId: {}, accept: {}",
-                        memberId, invitationId, request.accept());
+        log.debug("초대 응답 - memberId: {}, invitationId: {}, accept: {}", memberId, invitationId,
+                        request.accept());
 
         Member member = memberRepository.findById(memberId)
-                        .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_FOUND));
+                        .orElseThrow(() -> new BaseException(BaseResponseStatus.MEMBER_NOT_FOUND));
 
-        TeamInvitation invitation = teamInvitationRepository
-                        .findByIdAndInvitee(invitationId, member)
-                        .orElseThrow(() -> new BaseException(BaseResponseStatus.TEAM_INVITATION_NOT_FOUND));
+        TeamInvitation invitation =
+                        teamInvitationRepository.findByIdAndInvitee(invitationId, member)
+                                        .orElseThrow(() -> new BaseException(
+                                                        BaseResponseStatus.TEAM_INVITATION_NOT_FOUND));
 
         // 만료 확인 및 처리
         invitation.expireIfNeeded();
 
         if (!invitation.canBeProcessed()) {
-            throw new BaseException(invitation.isExpired()
-                            ? BaseResponseStatus.TEAM_INVITATION_EXPIRED
-                            : BaseResponseStatus.TEAM_INVITATION_NOT_PENDING);
+            throw new BaseException(invitation.isExpired() ?
+                            BaseResponseStatus.TEAM_INVITATION_EXPIRED :
+                            BaseResponseStatus.TEAM_INVITATION_NOT_PENDING);
         }
 
         String responseMessage;
@@ -177,7 +174,7 @@ public class TeamService {
             invitation.accept();
             teamInvitationRepository.save(invitation);
 
-            // ✅ TeamMemberRepository를 통한 안전한 저장
+            // TeamMemberRepository를 통한 안전한 저장
             Team team = invitation.getTeam();
 
             // 이미 팀 멤버인지 확인 (중복 방지)
@@ -198,18 +195,16 @@ public class TeamService {
             responseMessage = "팀 초대를 거절했습니다.";
         }
 
-        log.info("초대 응답 완료 - invitationId: {}, status: {}",
-                        invitation.getId(), invitation.getStatus());
+        log.debug("초대 응답 완료 - invitationId: {}, status: {}", invitation.getId(),
+                        invitation.getStatus());
 
         return TeamResponseDto.RespondToInvitationResponse.builder()
-                        .invitationId(invitation.getId())
-                        .status(invitation.getStatus())
-                        .message(responseMessage)
-                        .build();
+                        .invitationId(invitation.getId()).status(invitation.getStatus())
+                        .message(responseMessage).build();
     }
 
     /**
-     * ✅ 새로 추가: 모든 초대가 수락되었는지 확인하고 팀을 오픈 상태로 변경
+     * 모든 초대가 수락되었는지 확인하고 팀을 오픈 상태로 변경
      */
     @Transactional
     public void checkAndOpenTeam(Team team) {
@@ -221,7 +216,7 @@ public class TeamService {
             team.activate();
             teamRepository.save(team);
 
-            log.info("팀 오픈 상태 변경 - teamId: {}, 모든 초대가 수락됨", team.getId());
+            log.debug("팀 오픈 상태 변경 - teamId: {}, 모든 초대가 수락됨", team.getId());
         }
     }
 
@@ -237,7 +232,7 @@ public class TeamService {
         // 2. 초대할 멤버들 조회
         List<Member> invitees = memberRepository.findAllById(inviteMemberIds);
         if (invitees.size() != inviteMemberIds.size()) {
-            throw new BaseException(BaseResponseStatus.NOT_FOUND);
+            throw new BaseException(BaseResponseStatus.MEMBER_NOT_FOUND);
         }
 
         // 3. 모든 초대 대상이 친구인지 확인
@@ -260,17 +255,13 @@ public class TeamService {
     /**
      * 초대 정보 변환
      */
-    private List<TeamResponseDto.TeamInvitationInfo> convertToInvitationInfos(List<TeamInvitation> invitations) {
-        return invitations.stream()
-                        .map(invitation -> TeamResponseDto.TeamInvitationInfo.builder()
-                                        .invitationId(invitation.getId())
-                                        .inviteeId(invitation.getInvitee().getId())
-                                        .inviteeName(invitation.getInvitee().getNickname())
-                                        .inviteeNickname(invitation.getInvitee().getNickname())
-                                        .status(invitation.getStatus())
-                                        .createdAt(invitation.getCreatedAt())
-                                        .expiredAt(invitation.getExpiredAt())
-                                        .build())
-                        .collect(Collectors.toList());
+    private List<TeamResponseDto.TeamInvitationInfo> convertToInvitationInfos(
+                    List<TeamInvitation> invitations) {
+        return invitations.stream().map(invitation -> TeamResponseDto.TeamInvitationInfo.builder()
+                        .invitationId(invitation.getId()).inviteeId(invitation.getInvitee().getId())
+                        .inviteeName(invitation.getInvitee().getNickname())
+                        .inviteeNickname(invitation.getInvitee().getNickname())
+                        .status(invitation.getStatus()).createdAt(invitation.getCreatedAt())
+                        .expiredAt(invitation.getExpiredAt()).build()).collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/mini/buting/global/response/BaseResponseStatus.java
+++ b/src/main/java/com/mini/buting/global/response/BaseResponseStatus.java
@@ -111,10 +111,11 @@ public enum BaseResponseStatus {
     /**
      * 4500: 팀 시스템 관련 에러
      */
-    TEAM_NOT_FOUND(HttpStatus.NOT_FOUND, false, 4504, "팀을 찾을 수 없습니다."),
-    ALREADY_TEAM_LEADER(HttpStatus.BAD_REQUEST, false, 4505, "이미 다른 팀의 팀장입니다."),
-    TEAM_SIZE_MISMATCH(HttpStatus.BAD_REQUEST, false, 4507, "초대할 멤버 수가 팀 크기와 일치하지 않습니다."),
-    TEAM_NOT_READY(HttpStatus.BAD_REQUEST, false, 4508, "모든 멤버가 수락해야 팀이 활성화됩니다."),
+    TEAM_NOT_FOUND(HttpStatus.NOT_FOUND, false, 4501, "팀을 찾을 수 없습니다."),
+    ALREADY_TEAM_LEADER(HttpStatus.BAD_REQUEST, false, 4502, "이미 다른 팀의 팀장입니다."),
+    TEAM_SIZE_MISMATCH(HttpStatus.BAD_REQUEST, false, 4503, "초대할 멤버 수가 팀 크기와 일치하지 않습니다."),
+    DIFFERENT_GENDER_CANNOT_INVITE(HttpStatus.BAD_REQUEST, false, 4504, "다른 성별의 사용자는 초대할 수 없습니다."),
+    TEAM_NOT_READY(HttpStatus.BAD_REQUEST, false, 4505, "모든 멤버가 수락해야 팀이 활성화됩니다."),
 
     /**
      * 5000: 채팅방 관련 에러

--- a/src/main/java/com/mini/buting/global/response/BaseResponseStatus.java
+++ b/src/main/java/com/mini/buting/global/response/BaseResponseStatus.java
@@ -98,6 +98,23 @@ public enum BaseResponseStatus {
     COLLEGE_NOT_FOUND(HttpStatus.NOT_FOUND, false, 4302, "존재하지 않는 단과대입니다."),
     INVALID_UNIVERSITY_EMAIL(HttpStatus.BAD_REQUEST, false, 4303, "올바르지 않은 대학 이메일입니다."),
 
+    /**
+     * 4400: 팀 초대 관련 에러
+     */
+    TEAM_INVITATION_NOT_PENDING(HttpStatus.BAD_REQUEST, false, 4401, "대기 중인 초대가 아닙니다."),
+    TEAM_INVITATION_EXPIRED(HttpStatus.BAD_REQUEST, false, 4402, "만료된 초대입니다."),
+    TEAM_INVITATION_NOT_FOUND(HttpStatus.NOT_FOUND, false, 4403, "초대를 찾을 수 없습니다."),
+    ALREADY_INVITED_TO_TEAM(HttpStatus.BAD_REQUEST, false, 4404, "이미 해당 팀에 초대된 상태입니다."),
+    CANNOT_INVITE_SELF(HttpStatus.BAD_REQUEST, false, 4405, "자신을 초대할 수 없습니다."),
+    NOT_FRIEND_CANNOT_INVITE(HttpStatus.BAD_REQUEST, false, 4406, "친구만 초대할 수 있습니다."),
+
+    /**
+     * 4500: 팀 시스템 관련 에러
+     */
+    TEAM_NOT_FOUND(HttpStatus.NOT_FOUND, false, 4504, "팀을 찾을 수 없습니다."),
+    ALREADY_TEAM_LEADER(HttpStatus.BAD_REQUEST, false, 4505, "이미 다른 팀의 팀장입니다."),
+    TEAM_SIZE_MISMATCH(HttpStatus.BAD_REQUEST, false, 4507, "초대할 멤버 수가 팀 크기와 일치하지 않습니다."),
+    TEAM_NOT_READY(HttpStatus.BAD_REQUEST, false, 4508, "모든 멤버가 수락해야 팀이 활성화됩니다."),
 
     /**
      * 5000: 채팅방 관련 에러

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -8,7 +8,7 @@
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
             <pattern>${LOG_PATTERN}</pattern>
-            <charset>EUC-KR</charset>
+            <charset>UTF-8</charset> <!-- EUC-KR -> UTF-8 변경 -->
         </encoder>
     </appender>
 


### PR DESCRIPTION
<!--
🔀 Develop PR (제목을 입력해주세요)
🚑️ Hotfix MR (제목을 입력해주세요)

📌 사용 예시:
[🔀 FE]
[🔀 BE]
[🚑️ BE]
[🚑️ FE]

⚠️ (괄호) 항목은 모두 지우고 알맞게 작성해주세요.
-->

### 🔗 Connected Issue

Closes #37 

### 📅 Development Period

<!-- 작업 기간을 YYYY.MM.DD ~ YYYY.MM.DD 형식으로 입력해주세요 -->

2026.01.19 ~ 2026.01.21

### 📢 Description

다음 API를 구현했습니다.

POST `/v1/teams` 팀 생성
GET `/v1/teams/friends/search?keyword=박민수` 팀 생성 시 친구 검색(조회)(성별 필터링 적용)
PATCH `/v1/teams/invitations/{invitationId}/respond` 초대 응답
GET `/v1/teams/invitations/received` 내가 받은 팀 초대 목록

### ✔️ PR Checklist

MR이 아래 사항을 충족하는지 확인해주세요:

- [x] Merge 방향 및 Branch 확인했습니다.
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 코드가 정상적으로 동작하는지 테스트했습니다.
- [x] 해당하는 이슈번호를 올바르게 입력했습니다.

### 🔖 Note

<!-- 참고사항을 적어주세요 -->

PR이 너무 길어서 리뷰해달라고 하기가 민망하네요,, 죄송함니다 다음부터는 좀 쪼개서 올리도록 하겠습니다..
코드리뷰는 적당히만 봐주셔도 됩니다...

- Team 엔티티는 팀 관리 로직에 집중하기 위해 팀 선호 분위기, 팀 성별, 팀 사이즈 등은 따로 빼서 Enum 으로 분리하였습니다.
- 팀 초대를 위해 관련 엔티티를 생성했습니다.
- 팀을 생성할때는 친구 목록에서 올바르게 찾아서 팀 사이즈에 맞는 수만큼 초대해야 합니다.
- keyword에 닉네임 혹은 이메일의 일부를 넣으면 해당하는 멤버를 찾아서 검색합니다.
- 여기서의 친구 검색은 성별 필터링을 적용하여, API 사용 주체와 같은 성별의 친구만 검색합니다.
- 초대를 받은 모든 참여자가 초대에 수락해야 `is_open` 컬럼이 0에서 1로 업데이트됩니다.
- 로그에서 한글이 깨지는 이슈가 있어 logback-spring.xml 을 수정했습니다.