### PR TITLE
[🔀 BE] 매칭 요청 API 구현

### DIFF
--- a/src/main/java/com/mini/buting/api/chat/service/ChatService.java
+++ b/src/main/java/com/mini/buting/api/chat/service/ChatService.java
@@ -2,6 +2,7 @@ package com.mini.buting.api.chat.service;
 
 import com.mini.buting.api.chat.domain.chatmessage.ChatMessageDocument;
 import com.mini.buting.api.chat.domain.payload.TextPayload;
+import com.mini.buting.api.chat.domain.payload.WelcomePayload;
 import com.mini.buting.api.chat.dto.request.ChatMessageRequest;
 import com.mini.buting.api.chat.repository.ChatRoomMemberRepository;
 import com.mini.buting.api.chat.repository.ChatRoomRepository;
@@ -87,6 +88,12 @@ public class ChatService {
             case NOTICE:
                 return "공지가 등록되었습니다.";
 
+            case WELCOME:
+                WelcomePayload welcomePayload = (WelcomePayload) message.payload();
+                String welcomeText = welcomePayload.text();
+                return welcomeText.length() <= 15 ? welcomeText : welcomeText.substring(0, 15);
+
+            case TEXT:
             default:
                 TextPayload payload = (TextPayload) message.payload();
                 String text = payload.text();

--- a/src/main/java/com/mini/buting/api/matchRequest/controller/MatchRequestController.java
+++ b/src/main/java/com/mini/buting/api/matchRequest/controller/MatchRequestController.java
@@ -1,0 +1,82 @@
+package com.mini.buting.api.matchRequest.controller;
+
+import com.mini.buting.api.matchRequest.dto.request.MatchRequestRequestDto;
+import com.mini.buting.api.matchRequest.dto.response.MatchRequestResponseDto;
+import com.mini.buting.api.matchRequest.service.MatchRequestService;
+import com.mini.buting.global.response.BaseResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "MatchRequest", description = "팀 매칭 요청 API")
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/v1/match-requests")
+public class MatchRequestController {
+
+    private final MatchRequestService matchRequestService;
+
+    @Operation(summary = "매칭 요청 생성", description = "대상 팀에게 매칭 요청을 보냅니다.")
+    @PostMapping
+    public ResponseEntity<BaseResponse<MatchRequestResponseDto.MatchRequestCreateResponse>> createMatchRequest(
+            @Parameter(description = "사용자 ID", required = true)
+            @RequestHeader(value = "X-User-Id", required = false, defaultValue = "1") Long memberId,
+            @Valid @RequestBody MatchRequestRequestDto.CreateMatchRequest request
+    ) {
+        log.debug("매칭 요청 생성 - memberId: {}, targetTeamId: {}", memberId, request.targetTeamId());
+        MatchRequestResponseDto.MatchRequestCreateResponse response =
+                matchRequestService.createMatchRequest(memberId, request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(BaseResponse.onSuccess(response));
+    }
+
+    @Operation(summary = "매칭 요청 응답", description = "매칭 요청을 수락하거나 거절합니다.")
+    @PatchMapping("/{matchRequestId}/respond")
+    public ResponseEntity<BaseResponse<MatchRequestResponseDto.MatchRequestRespondResponse>> respondMatchRequest(
+            @Parameter(description = "사용자 ID", required = true)
+            @RequestHeader(value = "X-User-Id", required = false, defaultValue = "1") Long memberId,
+            @Parameter(description = "매칭 요청 ID", required = true)
+            @PathVariable Long matchRequestId,
+            @Valid @RequestBody MatchRequestRequestDto.RespondMatchRequest request
+    ) {
+        log.debug("매칭 요청 응답 - memberId: {}, matchRequestId: {}, accept: {}",
+                memberId, matchRequestId, request.accept());
+        MatchRequestResponseDto.MatchRequestRespondResponse response =
+                matchRequestService.respondMatchRequest(memberId, matchRequestId, request);
+        return ResponseEntity.ok(BaseResponse.onSuccess(response));
+    }
+
+    @Operation(summary = "매칭 요청 단건 조회", description = "매칭 요청 상세 정보를 조회합니다.")
+    @GetMapping("/{matchRequestId}")
+    public ResponseEntity<BaseResponse<MatchRequestResponseDto.MatchRequestDetailResponse>> getMatchRequest(
+            @Parameter(description = "사용자 ID", required = true)
+            @RequestHeader(value = "X-User-Id", required = false, defaultValue = "1") Long memberId,
+            @Parameter(description = "매칭 요청 ID", required = true)
+            @PathVariable Long matchRequestId
+    ) {
+        MatchRequestResponseDto.MatchRequestDetailResponse response =
+                matchRequestService.getMatchRequest(memberId, matchRequestId);
+        return ResponseEntity.ok(BaseResponse.onSuccess(response));
+    }
+
+    @Operation(summary = "매칭 요청 목록 조회", description = "보낸/받은 매칭 요청 목록을 조회합니다.")
+    @GetMapping
+    public ResponseEntity<BaseResponse<MatchRequestResponseDto.MatchRequestListResponse>> getMatchRequests(
+            @Parameter(description = "사용자 ID", required = true)
+            @RequestHeader(value = "X-User-Id", required = false, defaultValue = "1") Long memberId,
+            @Parameter(description = "sent | received", required = true)
+            @RequestParam String type,
+            @Parameter(description = "PENDING | ACCEPTED | REJECTED")
+            @RequestParam(required = false) String status
+    ) {
+        MatchRequestResponseDto.MatchRequestListResponse response =
+                matchRequestService.getMatchRequests(memberId, type, status);
+        return ResponseEntity.ok(BaseResponse.onSuccess(response));
+    }
+}

--- a/src/main/java/com/mini/buting/api/matchRequest/controller/MatchRequestController.java
+++ b/src/main/java/com/mini/buting/api/matchRequest/controller/MatchRequestController.java
@@ -26,57 +26,56 @@ public class MatchRequestController {
     @Operation(summary = "매칭 요청 생성", description = "대상 팀에게 매칭 요청을 보냅니다.")
     @PostMapping
     public ResponseEntity<BaseResponse<MatchRequestResponseDto.MatchRequestCreateResponse>> createMatchRequest(
-            @Parameter(description = "사용자 ID", required = true)
-            @RequestHeader(value = "X-User-Id", required = false, defaultValue = "1") Long memberId,
-            @Valid @RequestBody MatchRequestRequestDto.CreateMatchRequest request
-    ) {
+                    @Parameter(description = "사용자 ID", required = true)
+                    @RequestHeader(value = "X-User-Id", required = false, defaultValue = "1")
+                    Long memberId,
+                    @Valid @RequestBody MatchRequestRequestDto.CreateMatchRequest request) {
         log.debug("매칭 요청 생성 - memberId: {}, targetTeamId: {}", memberId, request.targetTeamId());
         MatchRequestResponseDto.MatchRequestCreateResponse response =
-                matchRequestService.createMatchRequest(memberId, request);
+                        matchRequestService.createMatchRequest(memberId, request);
         return ResponseEntity.status(HttpStatus.CREATED).body(BaseResponse.onSuccess(response));
     }
 
     @Operation(summary = "매칭 요청 응답", description = "매칭 요청을 수락하거나 거절합니다.")
     @PatchMapping("/{matchRequestId}/respond")
     public ResponseEntity<BaseResponse<MatchRequestResponseDto.MatchRequestRespondResponse>> respondMatchRequest(
-            @Parameter(description = "사용자 ID", required = true)
-            @RequestHeader(value = "X-User-Id", required = false, defaultValue = "1") Long memberId,
-            @Parameter(description = "매칭 요청 ID", required = true)
-            @PathVariable Long matchRequestId,
-            @Valid @RequestBody MatchRequestRequestDto.RespondMatchRequest request
-    ) {
-        log.debug("매칭 요청 응답 - memberId: {}, matchRequestId: {}, accept: {}",
-                memberId, matchRequestId, request.accept());
+                    @Parameter(description = "사용자 ID", required = true)
+                    @RequestHeader(value = "X-User-Id", required = false, defaultValue = "1")
+                    Long memberId,
+                    @Parameter(description = "매칭 요청 ID", required = true) @PathVariable
+                    Long matchRequestId,
+                    @Valid @RequestBody MatchRequestRequestDto.RespondMatchRequest request) {
+        log.debug("매칭 요청 응답 - memberId: {}, matchRequestId: {}, accept: {}", memberId,
+                        matchRequestId, request.accept());
         MatchRequestResponseDto.MatchRequestRespondResponse response =
-                matchRequestService.respondMatchRequest(memberId, matchRequestId, request);
+                        matchRequestService.respondMatchRequest(memberId, matchRequestId, request);
         return ResponseEntity.ok(BaseResponse.onSuccess(response));
     }
 
     @Operation(summary = "매칭 요청 단건 조회", description = "매칭 요청 상세 정보를 조회합니다.")
     @GetMapping("/{matchRequestId}")
     public ResponseEntity<BaseResponse<MatchRequestResponseDto.MatchRequestDetailResponse>> getMatchRequest(
-            @Parameter(description = "사용자 ID", required = true)
-            @RequestHeader(value = "X-User-Id", required = false, defaultValue = "1") Long memberId,
-            @Parameter(description = "매칭 요청 ID", required = true)
-            @PathVariable Long matchRequestId
-    ) {
+                    @Parameter(description = "사용자 ID", required = true)
+                    @RequestHeader(value = "X-User-Id", required = false, defaultValue = "1")
+                    Long memberId,
+                    @Parameter(description = "매칭 요청 ID", required = true) @PathVariable
+                    Long matchRequestId) {
         MatchRequestResponseDto.MatchRequestDetailResponse response =
-                matchRequestService.getMatchRequest(memberId, matchRequestId);
+                        matchRequestService.getMatchRequest(memberId, matchRequestId);
         return ResponseEntity.ok(BaseResponse.onSuccess(response));
     }
 
     @Operation(summary = "매칭 요청 목록 조회", description = "보낸/받은 매칭 요청 목록을 조회합니다.")
     @GetMapping
     public ResponseEntity<BaseResponse<MatchRequestResponseDto.MatchRequestListResponse>> getMatchRequests(
-            @Parameter(description = "사용자 ID", required = true)
-            @RequestHeader(value = "X-User-Id", required = false, defaultValue = "1") Long memberId,
-            @Parameter(description = "sent | received", required = true)
-            @RequestParam String type,
-            @Parameter(description = "PENDING | ACCEPTED | REJECTED")
-            @RequestParam(required = false) String status
-    ) {
+                    @Parameter(description = "사용자 ID", required = true)
+                    @RequestHeader(value = "X-User-Id", required = false, defaultValue = "1")
+                    Long memberId,
+                    @Parameter(description = "sent | received", required = true) @RequestParam
+                    String type, @Parameter(description = "PENDING | ACCEPTED | REJECTED")
+                    @RequestParam(required = false) String status) {
         MatchRequestResponseDto.MatchRequestListResponse response =
-                matchRequestService.getMatchRequests(memberId, type, status);
+                        matchRequestService.getMatchRequests(memberId, type, status);
         return ResponseEntity.ok(BaseResponse.onSuccess(response));
     }
 }

--- a/src/main/java/com/mini/buting/api/matchRequest/domain/MatchRequest.java
+++ b/src/main/java/com/mini/buting/api/matchRequest/domain/MatchRequest.java
@@ -86,7 +86,7 @@ public class MatchRequest extends BaseTimeEntity {
     }
 
     public void validateAcceptedStatus() {
-        if(status != MatchRequestStatus.ACCEPTED){
+        if (status != MatchRequestStatus.ACCEPTED) {
             throw new BaseException((BaseResponseStatus.MATCH_REQUEST_NOT_ACCEPTED));
         }
     }

--- a/src/main/java/com/mini/buting/api/matchRequest/dto/request/MatchRequestRequestDto.java
+++ b/src/main/java/com/mini/buting/api/matchRequest/dto/request/MatchRequestRequestDto.java
@@ -1,0 +1,21 @@
+package com.mini.buting.api.matchRequest.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+
+public class MatchRequestRequestDto {
+
+    @Builder
+    public record CreateMatchRequest(
+            @NotNull(message = "대상 팀 ID는 필수입니다.")
+            Long targetTeamId
+    ) {
+    }
+
+    @Builder
+    public record RespondMatchRequest(
+            @NotNull(message = "응답은 필수입니다.")
+            Boolean accept
+    ) {
+    }
+}

--- a/src/main/java/com/mini/buting/api/matchRequest/dto/request/MatchRequestRequestDto.java
+++ b/src/main/java/com/mini/buting/api/matchRequest/dto/request/MatchRequestRequestDto.java
@@ -6,16 +6,11 @@ import lombok.Builder;
 public class MatchRequestRequestDto {
 
     @Builder
-    public record CreateMatchRequest(
-            @NotNull(message = "대상 팀 ID는 필수입니다.")
-            Long targetTeamId
-    ) {
+    public record CreateMatchRequest(@NotNull(message = "대상 팀 ID는 필수입니다.") Long targetTeamId) {
     }
 
+
     @Builder
-    public record RespondMatchRequest(
-            @NotNull(message = "응답은 필수입니다.")
-            Boolean accept
-    ) {
+    public record RespondMatchRequest(@NotNull(message = "응답은 필수입니다.") Boolean accept) {
     }
 }

--- a/src/main/java/com/mini/buting/api/matchRequest/dto/response/MatchRequestResponseDto.java
+++ b/src/main/java/com/mini/buting/api/matchRequest/dto/response/MatchRequestResponseDto.java
@@ -11,68 +11,47 @@ import java.util.List;
 public class MatchRequestResponseDto {
 
     @Builder
-    public record MatchRequestCreateResponse(
-            Long matchRequestId,
-            String status,
-            Long requestTeamId,
-            Long targetTeamId,
-            @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
-            LocalDateTime createdAt
-    ) {
+    public record MatchRequestCreateResponse(Long matchRequestId, String status, Long requestTeamId,
+                                             Long targetTeamId,
+                                             @JsonFormat(shape = JsonFormat.Shape.STRING,
+                                                             pattern = "yyyy-MM-dd HH:mm:ss") LocalDateTime createdAt) {
     }
 
-    @Builder
-    public record MatchRequestRespondResponse(
-            Long matchRequestId,
-            String status,
-            Long chatRoomId,
-            @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
-            LocalDateTime updatedAt
-    ) {
-    }
 
     @Builder
-    public record MatchRequestDetailResponse(
-            Long matchRequestId,
-            String status,
-            TeamSummary requestTeam,
-            TeamSummary targetTeam,
-            @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
-            LocalDateTime createdAt,
-            @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
-            LocalDateTime updatedAt,
-            Boolean expired
-    ) {
+    public record MatchRequestRespondResponse(Long matchRequestId, String status, Long chatRoomId,
+                                              @JsonFormat(shape = JsonFormat.Shape.STRING,
+                                                              pattern = "yyyy-MM-dd HH:mm:ss") LocalDateTime updatedAt) {
     }
 
-    @Builder
-    public record MatchRequestSummary(
-            Long matchRequestId,
-            String status,
-            String requestedAtAgo,
-            String opponentTeamTitle,
-            TeamSize opponentTeamSize,
-            String opponentPreferredMood,
-            Integer opponentPreferredEntryYearMin,
-            Integer opponentPreferredEntryYearMax
-    ) {
-    }
 
     @Builder
-    public record MatchRequestListResponse(
-            List<MatchRequestSummary> requests,
-            Integer totalCount
-    ) {
+    public record MatchRequestDetailResponse(Long matchRequestId, String status,
+                                             TeamSummary requestTeam, TeamSummary targetTeam,
+                                             @JsonFormat(shape = JsonFormat.Shape.STRING,
+                                                             pattern = "yyyy-MM-dd HH:mm:ss") LocalDateTime createdAt,
+                                             @JsonFormat(shape = JsonFormat.Shape.STRING,
+                                                             pattern = "yyyy-MM-dd HH:mm:ss") LocalDateTime updatedAt,
+                                             Boolean expired) {
     }
 
+
     @Builder
-    public record TeamSummary(
-            Long teamId,
-            String title,
-            TeamSize teamSize,
-            Gender gender,
-            Integer currentMemberCount,
-            Integer targetMemberCount
-    ) {
+    public record MatchRequestSummary(Long matchRequestId, String status, String requestedAtAgo,
+                                      String opponentTeamTitle, TeamSize opponentTeamSize,
+                                      String opponentPreferredMood,
+                                      Integer opponentPreferredEntryYearMin,
+                                      Integer opponentPreferredEntryYearMax) {
+    }
+
+
+    @Builder
+    public record MatchRequestListResponse(List<MatchRequestSummary> requests, Integer totalCount) {
+    }
+
+
+    @Builder
+    public record TeamSummary(Long teamId, String title, TeamSize teamSize, Gender gender,
+                              Integer currentMemberCount, Integer targetMemberCount) {
     }
 }

--- a/src/main/java/com/mini/buting/api/matchRequest/dto/response/MatchRequestResponseDto.java
+++ b/src/main/java/com/mini/buting/api/matchRequest/dto/response/MatchRequestResponseDto.java
@@ -1,0 +1,76 @@
+package com.mini.buting.api.matchRequest.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.mini.buting.api.team.domain.Gender;
+import com.mini.buting.api.team.domain.TeamSize;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public class MatchRequestResponseDto {
+
+    @Builder
+    public record MatchRequestCreateResponse(
+            Long matchRequestId,
+            String status,
+            Long requestTeamId,
+            Long targetTeamId,
+            @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
+            LocalDateTime createdAt
+    ) {
+    }
+
+    @Builder
+    public record MatchRequestRespondResponse(
+            Long matchRequestId,
+            String status,
+            Long chatRoomId,
+            @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
+            LocalDateTime updatedAt
+    ) {
+    }
+
+    @Builder
+    public record MatchRequestDetailResponse(
+            Long matchRequestId,
+            String status,
+            TeamSummary requestTeam,
+            TeamSummary targetTeam,
+            @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
+            LocalDateTime createdAt,
+            @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
+            LocalDateTime updatedAt,
+            Boolean expired
+    ) {
+    }
+
+    @Builder
+    public record MatchRequestSummary(
+            Long matchRequestId,
+            String status,
+            TeamSummary requestTeam,
+            TeamSummary targetTeam,
+            @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
+            LocalDateTime createdAt
+    ) {
+    }
+
+    @Builder
+    public record MatchRequestListResponse(
+            List<MatchRequestSummary> requests,
+            Integer totalCount
+    ) {
+    }
+
+    @Builder
+    public record TeamSummary(
+            Long teamId,
+            String title,
+            TeamSize teamSize,
+            Gender gender,
+            Integer currentMemberCount,
+            Integer targetMemberCount
+    ) {
+    }
+}

--- a/src/main/java/com/mini/buting/api/matchRequest/dto/response/MatchRequestResponseDto.java
+++ b/src/main/java/com/mini/buting/api/matchRequest/dto/response/MatchRequestResponseDto.java
@@ -49,10 +49,12 @@ public class MatchRequestResponseDto {
     public record MatchRequestSummary(
             Long matchRequestId,
             String status,
-            TeamSummary requestTeam,
-            TeamSummary targetTeam,
-            @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
-            LocalDateTime createdAt
+            String requestedAtAgo,
+            String opponentTeamTitle,
+            TeamSize opponentTeamSize,
+            String opponentPreferredMood,
+            Integer opponentPreferredEntryYearMin,
+            Integer opponentPreferredEntryYearMax
     ) {
     }
 

--- a/src/main/java/com/mini/buting/api/matchRequest/repository/MatchRequestRepository.java
+++ b/src/main/java/com/mini/buting/api/matchRequest/repository/MatchRequestRepository.java
@@ -30,27 +30,53 @@ public interface MatchRequestRepository extends JpaRepository<MatchRequest, Long
     /**
      * 요청 팀 기준 목록 조회 (최신순)
      */
-    List<MatchRequest> findByRequestTeamOrderByCreatedAtDesc(Team requestTeam);
+    @Query("SELECT mr FROM MatchRequest mr " +
+            "JOIN FETCH mr.requestTeam " +
+            "JOIN FETCH mr.targetTeam " +
+            "WHERE mr.requestTeam = :requestTeam " +
+            "ORDER BY mr.createdAt DESC")
+    List<MatchRequest> findByRequestTeamWithTeamsOrderByCreatedAtDesc(
+            @Param("requestTeam") Team requestTeam
+    );
 
     /**
      * 대상 팀 기준 목록 조회 (최신순)
      */
-    List<MatchRequest> findByTargetTeamOrderByCreatedAtDesc(Team targetTeam);
+    @Query("SELECT mr FROM MatchRequest mr " +
+            "JOIN FETCH mr.requestTeam " +
+            "JOIN FETCH mr.targetTeam " +
+            "WHERE mr.targetTeam = :targetTeam " +
+            "ORDER BY mr.createdAt DESC")
+    List<MatchRequest> findByTargetTeamWithTeamsOrderByCreatedAtDesc(
+            @Param("targetTeam") Team targetTeam
+    );
 
     /**
      * 요청 팀 + 상태 기준 목록 조회 (최신순)
      */
-    List<MatchRequest> findByRequestTeamAndStatusOrderByCreatedAtDesc(
-            Team requestTeam,
-            MatchRequestStatus status
+    @Query("SELECT mr FROM MatchRequest mr " +
+            "JOIN FETCH mr.requestTeam " +
+            "JOIN FETCH mr.targetTeam " +
+            "WHERE mr.requestTeam = :requestTeam " +
+            "AND mr.status = :status " +
+            "ORDER BY mr.createdAt DESC")
+    List<MatchRequest> findByRequestTeamAndStatusWithTeamsOrderByCreatedAtDesc(
+            @Param("requestTeam") Team requestTeam,
+            @Param("status") MatchRequestStatus status
     );
 
     /**
      * 대상 팀 + 상태 기준 목록 조회 (최신순)
      */
-    List<MatchRequest> findByTargetTeamAndStatusOrderByCreatedAtDesc(
-            Team targetTeam,
-            MatchRequestStatus status
+    @Query("SELECT mr FROM MatchRequest mr " +
+            "JOIN FETCH mr.requestTeam " +
+            "JOIN FETCH mr.targetTeam " +
+            "WHERE mr.targetTeam = :targetTeam " +
+            "AND mr.status = :status " +
+            "ORDER BY mr.createdAt DESC")
+    List<MatchRequest> findByTargetTeamAndStatusWithTeamsOrderByCreatedAtDesc(
+            @Param("targetTeam") Team targetTeam,
+            @Param("status") MatchRequestStatus status
     );
 
     /**

--- a/src/main/java/com/mini/buting/api/matchRequest/repository/MatchRequestRepository.java
+++ b/src/main/java/com/mini/buting/api/matchRequest/repository/MatchRequestRepository.java
@@ -17,87 +17,50 @@ public interface MatchRequestRepository extends JpaRepository<MatchRequest, Long
     /**
      * 요청 팀/대상 팀 조합으로 특정 상태 요청 조회 (양방향)
      */
-    @Query("SELECT mr FROM MatchRequest mr " +
-            "WHERE ((mr.requestTeam = :teamA AND mr.targetTeam = :teamB) " +
-            "OR (mr.requestTeam = :teamB AND mr.targetTeam = :teamA)) " +
-            "AND mr.status = :status")
-    Optional<MatchRequest> findByTeamsAndStatus(
-            @Param("teamA") Team teamA,
-            @Param("teamB") Team teamB,
-            @Param("status") MatchRequestStatus status
-    );
+    @Query("SELECT mr FROM MatchRequest mr " + "WHERE ((mr.requestTeam = :teamA AND mr.targetTeam = :teamB) " + "OR (mr.requestTeam = :teamB AND mr.targetTeam = :teamA)) " + "AND mr.status = :status")
+    Optional<MatchRequest> findByTeamsAndStatus(@Param("teamA") Team teamA,
+                    @Param("teamB") Team teamB, @Param("status") MatchRequestStatus status);
 
     /**
      * 요청 팀 기준 목록 조회 (최신순)
      */
-    @Query("SELECT mr FROM MatchRequest mr " +
-            "JOIN FETCH mr.requestTeam " +
-            "JOIN FETCH mr.targetTeam " +
-            "WHERE mr.requestTeam = :requestTeam " +
-            "ORDER BY mr.createdAt DESC")
+    @Query("SELECT mr FROM MatchRequest mr " + "JOIN FETCH mr.requestTeam " + "JOIN FETCH mr.targetTeam " + "WHERE mr.requestTeam = :requestTeam " + "ORDER BY mr.createdAt DESC")
     List<MatchRequest> findByRequestTeamWithTeamsOrderByCreatedAtDesc(
-            @Param("requestTeam") Team requestTeam
-    );
+                    @Param("requestTeam") Team requestTeam);
 
     /**
      * 대상 팀 기준 목록 조회 (최신순)
      */
-    @Query("SELECT mr FROM MatchRequest mr " +
-            "JOIN FETCH mr.requestTeam " +
-            "JOIN FETCH mr.targetTeam " +
-            "WHERE mr.targetTeam = :targetTeam " +
-            "ORDER BY mr.createdAt DESC")
+    @Query("SELECT mr FROM MatchRequest mr " + "JOIN FETCH mr.requestTeam " + "JOIN FETCH mr.targetTeam " + "WHERE mr.targetTeam = :targetTeam " + "ORDER BY mr.createdAt DESC")
     List<MatchRequest> findByTargetTeamWithTeamsOrderByCreatedAtDesc(
-            @Param("targetTeam") Team targetTeam
-    );
+                    @Param("targetTeam") Team targetTeam);
 
     /**
      * 요청 팀 + 상태 기준 목록 조회 (최신순)
      */
-    @Query("SELECT mr FROM MatchRequest mr " +
-            "JOIN FETCH mr.requestTeam " +
-            "JOIN FETCH mr.targetTeam " +
-            "WHERE mr.requestTeam = :requestTeam " +
-            "AND mr.status = :status " +
-            "ORDER BY mr.createdAt DESC")
+    @Query("SELECT mr FROM MatchRequest mr " + "JOIN FETCH mr.requestTeam " + "JOIN FETCH mr.targetTeam " + "WHERE mr.requestTeam = :requestTeam " + "AND mr.status = :status " + "ORDER BY mr.createdAt DESC")
     List<MatchRequest> findByRequestTeamAndStatusWithTeamsOrderByCreatedAtDesc(
-            @Param("requestTeam") Team requestTeam,
-            @Param("status") MatchRequestStatus status
-    );
+                    @Param("requestTeam") Team requestTeam,
+                    @Param("status") MatchRequestStatus status);
 
     /**
      * 대상 팀 + 상태 기준 목록 조회 (최신순)
      */
-    @Query("SELECT mr FROM MatchRequest mr " +
-            "JOIN FETCH mr.requestTeam " +
-            "JOIN FETCH mr.targetTeam " +
-            "WHERE mr.targetTeam = :targetTeam " +
-            "AND mr.status = :status " +
-            "ORDER BY mr.createdAt DESC")
+    @Query("SELECT mr FROM MatchRequest mr " + "JOIN FETCH mr.requestTeam " + "JOIN FETCH mr.targetTeam " + "WHERE mr.targetTeam = :targetTeam " + "AND mr.status = :status " + "ORDER BY mr.createdAt DESC")
     List<MatchRequest> findByTargetTeamAndStatusWithTeamsOrderByCreatedAtDesc(
-            @Param("targetTeam") Team targetTeam,
-            @Param("status") MatchRequestStatus status
-    );
+                    @Param("targetTeam") Team targetTeam,
+                    @Param("status") MatchRequestStatus status);
 
     /**
      * 관계자 접근 가능한 단건 조회 (요청팀/대상팀 권한 체크용)
      */
-    @Query("SELECT mr FROM MatchRequest mr " +
-            "JOIN FETCH mr.requestTeam rt " +
-            "JOIN FETCH mr.targetTeam tt " +
-            "WHERE mr.id = :matchRequestId " +
-            "AND (rt.id = :teamId OR tt.id = :teamId)")
-    Optional<MatchRequest> findByIdAndTeamId(
-            @Param("matchRequestId") Long matchRequestId,
-            @Param("teamId") Long teamId
-    );
+    @Query("SELECT mr FROM MatchRequest mr " + "JOIN FETCH mr.requestTeam rt " + "JOIN FETCH mr.targetTeam tt " + "WHERE mr.id = :matchRequestId " + "AND (rt.id = :teamId OR tt.id = :teamId)")
+    Optional<MatchRequest> findByIdAndTeamId(@Param("matchRequestId") Long matchRequestId,
+                    @Param("teamId") Long teamId);
 
     /**
      * 상세 조회용 (팀 함께 로딩)
      */
-    @Query("SELECT mr FROM MatchRequest mr " +
-            "JOIN FETCH mr.requestTeam " +
-            "JOIN FETCH mr.targetTeam " +
-            "WHERE mr.id = :matchRequestId")
+    @Query("SELECT mr FROM MatchRequest mr " + "JOIN FETCH mr.requestTeam " + "JOIN FETCH mr.targetTeam " + "WHERE mr.id = :matchRequestId")
     Optional<MatchRequest> findByIdWithTeams(@Param("matchRequestId") Long matchRequestId);
 }

--- a/src/main/java/com/mini/buting/api/matchRequest/repository/MatchRequestRepository.java
+++ b/src/main/java/com/mini/buting/api/matchRequest/repository/MatchRequestRepository.java
@@ -1,9 +1,77 @@
 package com.mini.buting.api.matchRequest.repository;
 
 import com.mini.buting.api.matchRequest.domain.MatchRequest;
+import com.mini.buting.api.matchRequest.domain.MatchRequest.MatchRequestStatus;
+import com.mini.buting.api.team.domain.Team;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface MatchRequestRepository extends JpaRepository<MatchRequest, Long> {
+
+    /**
+     * 요청 팀/대상 팀 조합으로 특정 상태 요청 조회 (양방향)
+     */
+    @Query("SELECT mr FROM MatchRequest mr " +
+            "WHERE ((mr.requestTeam = :teamA AND mr.targetTeam = :teamB) " +
+            "OR (mr.requestTeam = :teamB AND mr.targetTeam = :teamA)) " +
+            "AND mr.status = :status")
+    Optional<MatchRequest> findByTeamsAndStatus(
+            @Param("teamA") Team teamA,
+            @Param("teamB") Team teamB,
+            @Param("status") MatchRequestStatus status
+    );
+
+    /**
+     * 요청 팀 기준 목록 조회 (최신순)
+     */
+    List<MatchRequest> findByRequestTeamOrderByCreatedAtDesc(Team requestTeam);
+
+    /**
+     * 대상 팀 기준 목록 조회 (최신순)
+     */
+    List<MatchRequest> findByTargetTeamOrderByCreatedAtDesc(Team targetTeam);
+
+    /**
+     * 요청 팀 + 상태 기준 목록 조회 (최신순)
+     */
+    List<MatchRequest> findByRequestTeamAndStatusOrderByCreatedAtDesc(
+            Team requestTeam,
+            MatchRequestStatus status
+    );
+
+    /**
+     * 대상 팀 + 상태 기준 목록 조회 (최신순)
+     */
+    List<MatchRequest> findByTargetTeamAndStatusOrderByCreatedAtDesc(
+            Team targetTeam,
+            MatchRequestStatus status
+    );
+
+    /**
+     * 관계자 접근 가능한 단건 조회 (요청팀/대상팀 권한 체크용)
+     */
+    @Query("SELECT mr FROM MatchRequest mr " +
+            "JOIN FETCH mr.requestTeam rt " +
+            "JOIN FETCH mr.targetTeam tt " +
+            "WHERE mr.id = :matchRequestId " +
+            "AND (rt.id = :teamId OR tt.id = :teamId)")
+    Optional<MatchRequest> findByIdAndTeamId(
+            @Param("matchRequestId") Long matchRequestId,
+            @Param("teamId") Long teamId
+    );
+
+    /**
+     * 상세 조회용 (팀 함께 로딩)
+     */
+    @Query("SELECT mr FROM MatchRequest mr " +
+            "JOIN FETCH mr.requestTeam " +
+            "JOIN FETCH mr.targetTeam " +
+            "WHERE mr.id = :matchRequestId")
+    Optional<MatchRequest> findByIdWithTeams(@Param("matchRequestId") Long matchRequestId);
 }

--- a/src/main/java/com/mini/buting/api/matchRequest/service/MatchRequestService.java
+++ b/src/main/java/com/mini/buting/api/matchRequest/service/MatchRequestService.java
@@ -197,21 +197,23 @@ public class MatchRequestService {
         if ("sent".equalsIgnoreCase(type)) {
             // 보낸 요청 목록
             requests = parsedStatus == null ?
-                    matchRequestRepository.findByRequestTeamOrderByCreatedAtDesc(leaderTeam) :
-                    matchRequestRepository.findByRequestTeamAndStatusOrderByCreatedAtDesc(
+                    matchRequestRepository.findByRequestTeamWithTeamsOrderByCreatedAtDesc(
+                            leaderTeam) :
+                    matchRequestRepository.findByRequestTeamAndStatusWithTeamsOrderByCreatedAtDesc(
                             leaderTeam, parsedStatus);
         } else if ("received".equalsIgnoreCase(type)) {
             // 받은 요청 목록
             requests = parsedStatus == null ?
-                    matchRequestRepository.findByTargetTeamOrderByCreatedAtDesc(leaderTeam) :
-                    matchRequestRepository.findByTargetTeamAndStatusOrderByCreatedAtDesc(
+                    matchRequestRepository.findByTargetTeamWithTeamsOrderByCreatedAtDesc(
+                            leaderTeam) :
+                    matchRequestRepository.findByTargetTeamAndStatusWithTeamsOrderByCreatedAtDesc(
                             leaderTeam, parsedStatus);
         } else {
             throw new BaseException(BaseResponseStatus.INVALID_REQUEST);
         }
 
         List<MatchRequestResponseDto.MatchRequestSummary> summaries = requests.stream()
-                .map(this::toSummary)
+                .map(matchRequest -> toSummary(matchRequest, type))
                 .toList();
 
         return MatchRequestResponseDto.MatchRequestListResponse.builder()
@@ -220,13 +222,22 @@ public class MatchRequestService {
                 .build();
     }
 
-    private MatchRequestResponseDto.MatchRequestSummary toSummary(MatchRequest matchRequest) {
+    private MatchRequestResponseDto.MatchRequestSummary toSummary(
+            MatchRequest matchRequest,
+            String type
+    ) {
+        Team opponentTeam = "received".equalsIgnoreCase(type)
+                ? matchRequest.getRequestTeam()
+                : matchRequest.getTargetTeam();
         return MatchRequestResponseDto.MatchRequestSummary.builder()
                 .matchRequestId(matchRequest.getId())
                 .status(matchRequest.getStatus().name())
-                .requestTeam(toTeamSummary(matchRequest.getRequestTeam()))
-                .targetTeam(toTeamSummary(matchRequest.getTargetTeam()))
-                .createdAt(matchRequest.getCreatedAt())
+                .requestedAtAgo(formatTimeAgo(matchRequest.getCreatedAt()))
+                .opponentTeamTitle(opponentTeam.getTitle())
+                .opponentTeamSize(opponentTeam.getTeamSize())
+                .opponentPreferredMood(opponentTeam.getPreferredMood().getDisplayName())
+                .opponentPreferredEntryYearMin(opponentTeam.getPreferredEntryYearMin().intValue())
+                .opponentPreferredEntryYearMax(opponentTeam.getPreferredEntryYearMax().intValue())
                 .build();
     }
 
@@ -259,6 +270,21 @@ public class MatchRequestService {
         // 활성 회원 조회
         return memberRepository.findById(memberId)
                 .orElseThrow(() -> new BaseException(BaseResponseStatus.MEMBER_NOT_FOUND));
+    }
+
+    private String formatTimeAgo(java.time.LocalDateTime createdAt) {
+        java.time.Duration duration = java.time.Duration.between(createdAt,
+                java.time.LocalDateTime.now());
+        long minutes = duration.toMinutes();
+        if (minutes < 60) {
+            return minutes + "분 전";
+        }
+        long hours = duration.toHours();
+        if (hours < 24) {
+            return hours + "시간 전";
+        }
+        long days = duration.toDays();
+        return days + "일 전";
     }
 
     private void validateTeamReady(Team team) {

--- a/src/main/java/com/mini/buting/api/matchRequest/service/MatchRequestService.java
+++ b/src/main/java/com/mini/buting/api/matchRequest/service/MatchRequestService.java
@@ -37,23 +37,21 @@ public class MatchRequestService {
     private final ChatRoomService chatRoomService;
 
     @Transactional
-    public MatchRequestResponseDto.MatchRequestCreateResponse createMatchRequest(
-            Long memberId,
-            MatchRequestRequestDto.CreateMatchRequest request
-    ) {
+    public MatchRequestResponseDto.MatchRequestCreateResponse createMatchRequest(Long memberId,
+                    MatchRequestRequestDto.CreateMatchRequest request) {
         // 요청자 조회
         Member member = getMember(memberId);
 
         // 요청 팀은 팀장 기준으로 식별
         Team requestTeam = teamRepository.findByLeader(member)
-                .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_TEAM_LEADER));
+                        .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_TEAM_LEADER));
 
         // 매칭 가능한 상태인지 확인
         validateTeamReady(requestTeam);
 
         // 대상 팀 조회
         Team targetTeam = teamRepository.findById(request.targetTeamId())
-                .orElseThrow(() -> new BaseException(BaseResponseStatus.TEAM_NOT_FOUND));
+                        .orElseThrow(() -> new BaseException(BaseResponseStatus.TEAM_NOT_FOUND));
 
         // 자기 팀으로는 요청 불가
         if (requestTeam.getId().equals(targetTeam.getId())) {
@@ -70,12 +68,12 @@ public class MatchRequestService {
 
         // 기존 요청(대기/수락) 중복 방지
         if (matchRequestRepository.findByTeamsAndStatus(requestTeam, targetTeam,
-                MatchRequestStatus.PENDING).isPresent()) {
+                        MatchRequestStatus.PENDING).isPresent()) {
             throw new BaseException(BaseResponseStatus.MATCH_REQUEST_ALREADY_EXISTS);
         }
 
         if (matchRequestRepository.findByTeamsAndStatus(requestTeam, targetTeam,
-                MatchRequestStatus.ACCEPTED).isPresent()) {
+                        MatchRequestStatus.ACCEPTED).isPresent()) {
             throw new BaseException(BaseResponseStatus.MATCH_REQUEST_ALREADY_EXISTS);
         }
 
@@ -88,36 +86,30 @@ public class MatchRequestService {
         }
 
         // 매칭 요청 생성
-        MatchRequest matchRequest = MatchRequest.builder()
-                .requestTeam(requestTeam)
-                .targetTeam(targetTeam)
-                .build();
+        MatchRequest matchRequest =
+                        MatchRequest.builder().requestTeam(requestTeam).targetTeam(targetTeam)
+                                        .build();
 
         MatchRequest saved = matchRequestRepository.save(matchRequest);
 
         return MatchRequestResponseDto.MatchRequestCreateResponse.builder()
-                .matchRequestId(saved.getId())
-                .status(saved.getStatus().name())
-                .requestTeamId(requestTeam.getId())
-                .targetTeamId(targetTeam.getId())
-                .createdAt(saved.getCreatedAt())
-                .build();
+                        .matchRequestId(saved.getId()).status(saved.getStatus().name())
+                        .requestTeamId(requestTeam.getId()).targetTeamId(targetTeam.getId())
+                        .createdAt(saved.getCreatedAt()).build();
     }
 
     @Transactional
-    public MatchRequestResponseDto.MatchRequestRespondResponse respondMatchRequest(
-            Long memberId,
-            Long matchRequestId,
-            MatchRequestRequestDto.RespondMatchRequest request
-    ) {
+    public MatchRequestResponseDto.MatchRequestRespondResponse respondMatchRequest(Long memberId,
+                    Long matchRequestId, MatchRequestRequestDto.RespondMatchRequest request) {
         // 응답자(대상 팀 리더) 확인
         Member member = getMember(memberId);
         Team leaderTeam = teamRepository.findByLeader(member)
-                .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_TEAM_LEADER));
+                        .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_TEAM_LEADER));
 
         // 요청 및 연관 팀 로딩
         MatchRequest matchRequest = matchRequestRepository.findByIdWithTeams(matchRequestId)
-                .orElseThrow(() -> new BaseException(BaseResponseStatus.MATCH_REQUEST_NOT_FOUND));
+                        .orElseThrow(() -> new BaseException(
+                                        BaseResponseStatus.MATCH_REQUEST_NOT_FOUND));
 
         // 대상 팀 리더만 응답 가능
         if (!leaderTeam.getId().equals(matchRequest.getTargetTeam().getId())) {
@@ -128,8 +120,8 @@ public class MatchRequestService {
         matchRequest.expireIfNeeded();
         if (!matchRequest.canBeProcessed()) {
             throw new BaseException(matchRequest.isExpired() ?
-                    BaseResponseStatus.MATCH_REQUEST_EXPIRED :
-                    BaseResponseStatus.MATCH_REQUEST_NOT_PENDING);
+                            BaseResponseStatus.MATCH_REQUEST_EXPIRED :
+                            BaseResponseStatus.MATCH_REQUEST_NOT_PENDING);
         }
 
         Long chatRoomId = null;
@@ -148,47 +140,40 @@ public class MatchRequestService {
         }
 
         return MatchRequestResponseDto.MatchRequestRespondResponse.builder()
-                .matchRequestId(matchRequest.getId())
-                .status(matchRequest.getStatus().name())
-                .chatRoomId(chatRoomId)
-                .updatedAt(matchRequest.getUpdatedAt())
-                .build();
+                        .matchRequestId(matchRequest.getId())
+                        .status(matchRequest.getStatus().name()).chatRoomId(chatRoomId)
+                        .updatedAt(matchRequest.getUpdatedAt()).build();
     }
 
-    public MatchRequestResponseDto.MatchRequestDetailResponse getMatchRequest(
-            Long memberId,
-            Long matchRequestId
-    ) {
+    public MatchRequestResponseDto.MatchRequestDetailResponse getMatchRequest(Long memberId,
+                    Long matchRequestId) {
         // 요청자 팀(리더) 기준 권한 확인
         Member member = getMember(memberId);
         Team leaderTeam = teamRepository.findByLeader(member)
-                .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_TEAM_LEADER));
+                        .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_TEAM_LEADER));
 
         // 요청 팀 또는 대상 팀만 조회 가능
-        MatchRequest matchRequest = matchRequestRepository.findByIdAndTeamId(
-                        matchRequestId, leaderTeam.getId())
-                .orElseThrow(() -> new BaseException(BaseResponseStatus.MATCH_REQUEST_NOT_FOUND));
+        MatchRequest matchRequest =
+                        matchRequestRepository.findByIdAndTeamId(matchRequestId, leaderTeam.getId())
+                                        .orElseThrow(() -> new BaseException(
+                                                        BaseResponseStatus.MATCH_REQUEST_NOT_FOUND));
 
         return MatchRequestResponseDto.MatchRequestDetailResponse.builder()
-                .matchRequestId(matchRequest.getId())
-                .status(matchRequest.getStatus().name())
-                .requestTeam(toTeamSummary(matchRequest.getRequestTeam()))
-                .targetTeam(toTeamSummary(matchRequest.getTargetTeam()))
-                .createdAt(matchRequest.getCreatedAt())
-                .updatedAt(matchRequest.getUpdatedAt())
-                .expired(matchRequest.isExpired())
-                .build();
+                        .matchRequestId(matchRequest.getId())
+                        .status(matchRequest.getStatus().name())
+                        .requestTeam(toTeamSummary(matchRequest.getRequestTeam()))
+                        .targetTeam(toTeamSummary(matchRequest.getTargetTeam()))
+                        .createdAt(matchRequest.getCreatedAt())
+                        .updatedAt(matchRequest.getUpdatedAt()).expired(matchRequest.isExpired())
+                        .build();
     }
 
-    public MatchRequestResponseDto.MatchRequestListResponse getMatchRequests(
-            Long memberId,
-            String type,
-            String status
-    ) {
+    public MatchRequestResponseDto.MatchRequestListResponse getMatchRequests(Long memberId,
+                    String type, String status) {
         // 팀 리더 기준 목록 조회
         Member member = getMember(memberId);
         Team leaderTeam = teamRepository.findByLeader(member)
-                .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_TEAM_LEADER));
+                        .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_TEAM_LEADER));
 
         // 상태 파라미터 파싱
         MatchRequestStatus parsedStatus = parseStatus(status);
@@ -197,61 +182,54 @@ public class MatchRequestService {
         if ("sent".equalsIgnoreCase(type)) {
             // 보낸 요청 목록
             requests = parsedStatus == null ?
-                    matchRequestRepository.findByRequestTeamWithTeamsOrderByCreatedAtDesc(
-                            leaderTeam) :
-                    matchRequestRepository.findByRequestTeamAndStatusWithTeamsOrderByCreatedAtDesc(
-                            leaderTeam, parsedStatus);
+                            matchRequestRepository.findByRequestTeamWithTeamsOrderByCreatedAtDesc(
+                                            leaderTeam) :
+                            matchRequestRepository.findByRequestTeamAndStatusWithTeamsOrderByCreatedAtDesc(
+                                            leaderTeam, parsedStatus);
         } else if ("received".equalsIgnoreCase(type)) {
             // 받은 요청 목록
             requests = parsedStatus == null ?
-                    matchRequestRepository.findByTargetTeamWithTeamsOrderByCreatedAtDesc(
-                            leaderTeam) :
-                    matchRequestRepository.findByTargetTeamAndStatusWithTeamsOrderByCreatedAtDesc(
-                            leaderTeam, parsedStatus);
+                            matchRequestRepository.findByTargetTeamWithTeamsOrderByCreatedAtDesc(
+                                            leaderTeam) :
+                            matchRequestRepository.findByTargetTeamAndStatusWithTeamsOrderByCreatedAtDesc(
+                                            leaderTeam, parsedStatus);
         } else {
             throw new BaseException(BaseResponseStatus.INVALID_REQUEST);
         }
 
-        List<MatchRequestResponseDto.MatchRequestSummary> summaries = requests.stream()
-                .map(matchRequest -> toSummary(matchRequest, type))
-                .toList();
+        List<MatchRequestResponseDto.MatchRequestSummary> summaries =
+                        requests.stream().map(matchRequest -> toSummary(matchRequest, type))
+                                        .toList();
 
-        return MatchRequestResponseDto.MatchRequestListResponse.builder()
-                .requests(summaries)
-                .totalCount(summaries.size())
-                .build();
+        return MatchRequestResponseDto.MatchRequestListResponse.builder().requests(summaries)
+                        .totalCount(summaries.size()).build();
     }
 
-    private MatchRequestResponseDto.MatchRequestSummary toSummary(
-            MatchRequest matchRequest,
-            String type
-    ) {
-        Team opponentTeam = "received".equalsIgnoreCase(type)
-                ? matchRequest.getRequestTeam()
-                : matchRequest.getTargetTeam();
+    private MatchRequestResponseDto.MatchRequestSummary toSummary(MatchRequest matchRequest,
+                    String type) {
+        Team opponentTeam = "received".equalsIgnoreCase(type) ?
+                        matchRequest.getRequestTeam() :
+                        matchRequest.getTargetTeam();
         return MatchRequestResponseDto.MatchRequestSummary.builder()
-                .matchRequestId(matchRequest.getId())
-                .status(matchRequest.getStatus().name())
-                .requestedAtAgo(formatTimeAgo(matchRequest.getCreatedAt()))
-                .opponentTeamTitle(opponentTeam.getTitle())
-                .opponentTeamSize(opponentTeam.getTeamSize())
-                .opponentPreferredMood(opponentTeam.getPreferredMood().getDisplayName())
-                .opponentPreferredEntryYearMin(opponentTeam.getPreferredEntryYearMin().intValue())
-                .opponentPreferredEntryYearMax(opponentTeam.getPreferredEntryYearMax().intValue())
-                .build();
+                        .matchRequestId(matchRequest.getId())
+                        .status(matchRequest.getStatus().name())
+                        .requestedAtAgo(formatTimeAgo(matchRequest.getCreatedAt()))
+                        .opponentTeamTitle(opponentTeam.getTitle())
+                        .opponentTeamSize(opponentTeam.getTeamSize())
+                        .opponentPreferredMood(opponentTeam.getPreferredMood().getDisplayName())
+                        .opponentPreferredEntryYearMin(
+                                        opponentTeam.getPreferredEntryYearMin().intValue())
+                        .opponentPreferredEntryYearMax(
+                                        opponentTeam.getPreferredEntryYearMax().intValue()).build();
     }
 
     private MatchRequestResponseDto.TeamSummary toTeamSummary(Team team) {
         // 현재 인원은 TeamMember 기준 카운트
         int currentMemberCount = (int) teamMemberRepository.countByTeam(team);
-        return MatchRequestResponseDto.TeamSummary.builder()
-                .teamId(team.getId())
-                .title(team.getTitle())
-                .teamSize(team.getTeamSize())
-                .gender(team.getGender())
-                .currentMemberCount(currentMemberCount)
-                .targetMemberCount(team.getTeamSize().getSize())
-                .build();
+        return MatchRequestResponseDto.TeamSummary.builder().teamId(team.getId())
+                        .title(team.getTitle()).teamSize(team.getTeamSize())
+                        .gender(team.getGender()).currentMemberCount(currentMemberCount)
+                        .targetMemberCount(team.getTeamSize().getSize()).build();
     }
 
     private MatchRequestStatus parseStatus(String status) {
@@ -269,12 +247,12 @@ public class MatchRequestService {
     private Member getMember(Long memberId) {
         // 활성 회원 조회
         return memberRepository.findById(memberId)
-                .orElseThrow(() -> new BaseException(BaseResponseStatus.MEMBER_NOT_FOUND));
+                        .orElseThrow(() -> new BaseException(BaseResponseStatus.MEMBER_NOT_FOUND));
     }
 
     private String formatTimeAgo(java.time.LocalDateTime createdAt) {
-        java.time.Duration duration = java.time.Duration.between(createdAt,
-                java.time.LocalDateTime.now());
+        java.time.Duration duration =
+                        java.time.Duration.between(createdAt, java.time.LocalDateTime.now());
         long minutes = duration.toMinutes();
         if (minutes < 60) {
             return minutes + "분 전";

--- a/src/main/java/com/mini/buting/api/matchRequest/service/MatchRequestService.java
+++ b/src/main/java/com/mini/buting/api/matchRequest/service/MatchRequestService.java
@@ -1,0 +1,270 @@
+package com.mini.buting.api.matchRequest.service;
+
+import com.mini.buting.api.chat.domain.chatroom.ChatRoom;
+import com.mini.buting.api.chat.repository.ChatRoomRepository;
+import com.mini.buting.api.chat.service.ChatRoomService;
+import com.mini.buting.api.matchRequest.domain.MatchRequest;
+import com.mini.buting.api.matchRequest.domain.MatchRequest.MatchRequestStatus;
+import com.mini.buting.api.matchRequest.dto.request.MatchRequestRequestDto;
+import com.mini.buting.api.matchRequest.dto.response.MatchRequestResponseDto;
+import com.mini.buting.api.matchRequest.repository.MatchRequestRepository;
+import com.mini.buting.api.member.domain.Member;
+import com.mini.buting.api.member.repository.MemberRepository;
+import com.mini.buting.api.team.domain.Gender;
+import com.mini.buting.api.team.domain.Team;
+import com.mini.buting.api.team.repository.TeamMemberRepository;
+import com.mini.buting.api.team.repository.TeamRepository;
+import com.mini.buting.global.exception.BaseException;
+import com.mini.buting.global.response.BaseResponseStatus;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+@Transactional(readOnly = true)
+public class MatchRequestService {
+
+    private final MatchRequestRepository matchRequestRepository;
+    private final TeamRepository teamRepository;
+    private final TeamMemberRepository teamMemberRepository;
+    private final MemberRepository memberRepository;
+    private final ChatRoomRepository chatRoomRepository;
+    private final ChatRoomService chatRoomService;
+
+    @Transactional
+    public MatchRequestResponseDto.MatchRequestCreateResponse createMatchRequest(
+            Long memberId,
+            MatchRequestRequestDto.CreateMatchRequest request
+    ) {
+        // 요청자 조회
+        Member member = getMember(memberId);
+
+        // 요청 팀은 팀장 기준으로 식별
+        Team requestTeam = teamRepository.findByLeader(member)
+                .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_TEAM_LEADER));
+
+        // 매칭 가능한 상태인지 확인
+        validateTeamReady(requestTeam);
+
+        // 대상 팀 조회
+        Team targetTeam = teamRepository.findById(request.targetTeamId())
+                .orElseThrow(() -> new BaseException(BaseResponseStatus.TEAM_NOT_FOUND));
+
+        // 자기 팀으로는 요청 불가
+        if (requestTeam.getId().equals(targetTeam.getId())) {
+            throw new BaseException(BaseResponseStatus.MATCH_REQUEST_SELF);
+        }
+
+        // 성별 매칭 제한
+        if (requestTeam.getGender() == targetTeam.getGender()) {
+            throw new BaseException(BaseResponseStatus.MATCH_REQUEST_SAME_GENDER);
+        }
+
+        // 대상 팀도 매칭 가능한 상태인지 확인
+        validateTeamReady(targetTeam);
+
+        // 기존 요청(대기/수락) 중복 방지
+        if (matchRequestRepository.findByTeamsAndStatus(requestTeam, targetTeam,
+                MatchRequestStatus.PENDING).isPresent()) {
+            throw new BaseException(BaseResponseStatus.MATCH_REQUEST_ALREADY_EXISTS);
+        }
+
+        if (matchRequestRepository.findByTeamsAndStatus(requestTeam, targetTeam,
+                MatchRequestStatus.ACCEPTED).isPresent()) {
+            throw new BaseException(BaseResponseStatus.MATCH_REQUEST_ALREADY_EXISTS);
+        }
+
+        // 이미 채팅방이 존재하면 요청 불가
+        Team maleTeam = requestTeam.getGender() == Gender.MALE ? requestTeam : targetTeam;
+        Team femaleTeam = requestTeam.getGender() == Gender.MALE ? targetTeam : requestTeam;
+
+        if (chatRoomRepository.existsByMaleTeamAndFemaleTeam(maleTeam, femaleTeam)) {
+            throw new BaseException(BaseResponseStatus.CHATROOM_ALREADY_EXISTS);
+        }
+
+        // 매칭 요청 생성
+        MatchRequest matchRequest = MatchRequest.builder()
+                .requestTeam(requestTeam)
+                .targetTeam(targetTeam)
+                .build();
+
+        MatchRequest saved = matchRequestRepository.save(matchRequest);
+
+        return MatchRequestResponseDto.MatchRequestCreateResponse.builder()
+                .matchRequestId(saved.getId())
+                .status(saved.getStatus().name())
+                .requestTeamId(requestTeam.getId())
+                .targetTeamId(targetTeam.getId())
+                .createdAt(saved.getCreatedAt())
+                .build();
+    }
+
+    @Transactional
+    public MatchRequestResponseDto.MatchRequestRespondResponse respondMatchRequest(
+            Long memberId,
+            Long matchRequestId,
+            MatchRequestRequestDto.RespondMatchRequest request
+    ) {
+        // 응답자(대상 팀 리더) 확인
+        Member member = getMember(memberId);
+        Team leaderTeam = teamRepository.findByLeader(member)
+                .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_TEAM_LEADER));
+
+        // 요청 및 연관 팀 로딩
+        MatchRequest matchRequest = matchRequestRepository.findByIdWithTeams(matchRequestId)
+                .orElseThrow(() -> new BaseException(BaseResponseStatus.MATCH_REQUEST_NOT_FOUND));
+
+        // 대상 팀 리더만 응답 가능
+        if (!leaderTeam.getId().equals(matchRequest.getTargetTeam().getId())) {
+            throw new BaseException(BaseResponseStatus.NOT_TEAM_LEADER);
+        }
+
+        // 만료/상태 검증
+        matchRequest.expireIfNeeded();
+        if (!matchRequest.canBeProcessed()) {
+            throw new BaseException(matchRequest.isExpired() ?
+                    BaseResponseStatus.MATCH_REQUEST_EXPIRED :
+                    BaseResponseStatus.MATCH_REQUEST_NOT_PENDING);
+        }
+
+        Long chatRoomId = null;
+        if (Boolean.TRUE.equals(request.accept())) {
+            // 수락 시 채팅방 생성 + 환영 메시지
+            matchRequest.accept();
+            matchRequestRepository.save(matchRequest);
+
+            ChatRoom room = chatRoomService.createRoom(matchRequest);
+            chatRoomService.sendWelcomeMessage(room.getRoomId(), room.getLeader().getId());
+            chatRoomId = room.getRoomId();
+        } else {
+            // 거절 처리
+            matchRequest.reject();
+            matchRequestRepository.save(matchRequest);
+        }
+
+        return MatchRequestResponseDto.MatchRequestRespondResponse.builder()
+                .matchRequestId(matchRequest.getId())
+                .status(matchRequest.getStatus().name())
+                .chatRoomId(chatRoomId)
+                .updatedAt(matchRequest.getUpdatedAt())
+                .build();
+    }
+
+    public MatchRequestResponseDto.MatchRequestDetailResponse getMatchRequest(
+            Long memberId,
+            Long matchRequestId
+    ) {
+        // 요청자 팀(리더) 기준 권한 확인
+        Member member = getMember(memberId);
+        Team leaderTeam = teamRepository.findByLeader(member)
+                .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_TEAM_LEADER));
+
+        // 요청 팀 또는 대상 팀만 조회 가능
+        MatchRequest matchRequest = matchRequestRepository.findByIdAndTeamId(
+                        matchRequestId, leaderTeam.getId())
+                .orElseThrow(() -> new BaseException(BaseResponseStatus.MATCH_REQUEST_NOT_FOUND));
+
+        return MatchRequestResponseDto.MatchRequestDetailResponse.builder()
+                .matchRequestId(matchRequest.getId())
+                .status(matchRequest.getStatus().name())
+                .requestTeam(toTeamSummary(matchRequest.getRequestTeam()))
+                .targetTeam(toTeamSummary(matchRequest.getTargetTeam()))
+                .createdAt(matchRequest.getCreatedAt())
+                .updatedAt(matchRequest.getUpdatedAt())
+                .expired(matchRequest.isExpired())
+                .build();
+    }
+
+    public MatchRequestResponseDto.MatchRequestListResponse getMatchRequests(
+            Long memberId,
+            String type,
+            String status
+    ) {
+        // 팀 리더 기준 목록 조회
+        Member member = getMember(memberId);
+        Team leaderTeam = teamRepository.findByLeader(member)
+                .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_TEAM_LEADER));
+
+        // 상태 파라미터 파싱
+        MatchRequestStatus parsedStatus = parseStatus(status);
+
+        List<MatchRequest> requests;
+        if ("sent".equalsIgnoreCase(type)) {
+            // 보낸 요청 목록
+            requests = parsedStatus == null ?
+                    matchRequestRepository.findByRequestTeamOrderByCreatedAtDesc(leaderTeam) :
+                    matchRequestRepository.findByRequestTeamAndStatusOrderByCreatedAtDesc(
+                            leaderTeam, parsedStatus);
+        } else if ("received".equalsIgnoreCase(type)) {
+            // 받은 요청 목록
+            requests = parsedStatus == null ?
+                    matchRequestRepository.findByTargetTeamOrderByCreatedAtDesc(leaderTeam) :
+                    matchRequestRepository.findByTargetTeamAndStatusOrderByCreatedAtDesc(
+                            leaderTeam, parsedStatus);
+        } else {
+            throw new BaseException(BaseResponseStatus.INVALID_REQUEST);
+        }
+
+        List<MatchRequestResponseDto.MatchRequestSummary> summaries = requests.stream()
+                .map(this::toSummary)
+                .toList();
+
+        return MatchRequestResponseDto.MatchRequestListResponse.builder()
+                .requests(summaries)
+                .totalCount(summaries.size())
+                .build();
+    }
+
+    private MatchRequestResponseDto.MatchRequestSummary toSummary(MatchRequest matchRequest) {
+        return MatchRequestResponseDto.MatchRequestSummary.builder()
+                .matchRequestId(matchRequest.getId())
+                .status(matchRequest.getStatus().name())
+                .requestTeam(toTeamSummary(matchRequest.getRequestTeam()))
+                .targetTeam(toTeamSummary(matchRequest.getTargetTeam()))
+                .createdAt(matchRequest.getCreatedAt())
+                .build();
+    }
+
+    private MatchRequestResponseDto.TeamSummary toTeamSummary(Team team) {
+        // 현재 인원은 TeamMember 기준 카운트
+        int currentMemberCount = (int) teamMemberRepository.countByTeam(team);
+        return MatchRequestResponseDto.TeamSummary.builder()
+                .teamId(team.getId())
+                .title(team.getTitle())
+                .teamSize(team.getTeamSize())
+                .gender(team.getGender())
+                .currentMemberCount(currentMemberCount)
+                .targetMemberCount(team.getTeamSize().getSize())
+                .build();
+    }
+
+    private MatchRequestStatus parseStatus(String status) {
+        // null/blank면 필터 미적용
+        if (status == null || status.isBlank()) {
+            return null;
+        }
+        try {
+            return MatchRequestStatus.valueOf(status.toUpperCase());
+        } catch (IllegalArgumentException ex) {
+            throw new BaseException(BaseResponseStatus.INVALID_REQUEST);
+        }
+    }
+
+    private Member getMember(Long memberId) {
+        // 활성 회원 조회
+        return memberRepository.findById(memberId)
+                .orElseThrow(() -> new BaseException(BaseResponseStatus.MEMBER_NOT_FOUND));
+    }
+
+    private void validateTeamReady(Team team) {
+        // 팀 상태가 매칭 가능해야 함
+        if (!team.canRequestMatch()) {
+            throw new BaseException(BaseResponseStatus.TEAM_NOT_READY);
+        }
+    }
+}

--- a/src/main/java/com/mini/buting/global/response/BaseResponseStatus.java
+++ b/src/main/java/com/mini/buting/global/response/BaseResponseStatus.java
@@ -76,7 +76,11 @@ public enum BaseResponseStatus {
      */
     MATCH_REQUEST_NOT_PENDING(HttpStatus.BAD_REQUEST, false, 4001, "대기 중인 매칭 요청이 아닙니다."),
     MATCH_REQUEST_EXPIRED(HttpStatus.BAD_REQUEST, false, 4002, "만료된 매칭 요청입니다."),
-    MATCH_REQUEST_NOT_ACCEPTED(HttpStatus.BAD_REQUEST, false, 4001, "수락 된 매칭 요청이 아닙니다."),
+    MATCH_REQUEST_NOT_ACCEPTED(HttpStatus.BAD_REQUEST, false, 4003, "수락 된 매칭 요청이 아닙니다."),
+    MATCH_REQUEST_NOT_FOUND(HttpStatus.NOT_FOUND, false, 4004, "매칭 요청을 찾을 수 없습니다."),
+    MATCH_REQUEST_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, false, 4005, "이미 존재하는 매칭 요청입니다."),
+    MATCH_REQUEST_SELF(HttpStatus.BAD_REQUEST, false, 4006, "같은 팀으로는 매칭 요청을 보낼 수 없습니다."),
+    MATCH_REQUEST_SAME_GENDER(HttpStatus.BAD_REQUEST, false, 4007, "같은 성별 팀과는 매칭할 수 없습니다."),
     /**
      * 4100: MBTI 관련 에러
      */


### PR DESCRIPTION
[🔀 BE] 매칭 요청 API 구현 및 응답 개선

### 🔗 Connected Issue

Closes #39

### 📅 Development Period

2026.01.28 ~ 2026.01.28

### 📢 Description

매칭 요청 생성/수락/거절/조회/목록 API를 추가했습니다.
받은 매칭 요청 목록에 필요한 정보(요청 시간, 상대 팀 요약)를 응답에 반영했고, WELCOME 메시지 프리뷰 처리 오류를 수정했습니다.

POST `/v1/match-requests` 매칭 요청 생성
PATCH `/v1/match-requests/{id}/respond` 매칭 요청 수락/거절
GET `/v1/match-requests/{id}` 매칭 요청 단건 조회
GET `/v1/match-requests?type=sent|received&status=...` 내가 받은 매칭 요청 목록 조회

### ✔️ PR Checklist

MR이 아래 사항을 충족하는지 확인해주세요:

- [x] Merge 방향 및 Branch 확인했습니다.
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 코드가 정상적으로 동작하는지 테스트했습니다.
- [x] 해당하는 이슈번호를 올바르게 입력했습니다.

### 🔖 Note