### PR TITLE
[🔀 BE] 팀 조회, 팀 수정 및 삭제 API 구현

### DIFF
--- a/src/main/java/com/mini/buting/api/chat/service/ChatService.java
+++ b/src/main/java/com/mini/buting/api/chat/service/ChatService.java
@@ -2,6 +2,7 @@ package com.mini.buting.api.chat.service;
 
 import com.mini.buting.api.chat.domain.chatmessage.ChatMessageDocument;
 import com.mini.buting.api.chat.domain.payload.TextPayload;
+import com.mini.buting.api.chat.domain.payload.WelcomePayload;
 import com.mini.buting.api.chat.dto.request.ChatMessageRequest;
 import com.mini.buting.api.chat.repository.ChatRoomMemberRepository;
 import com.mini.buting.api.chat.repository.ChatRoomRepository;
@@ -87,6 +88,12 @@ public class ChatService {
             case NOTICE:
                 return "공지가 등록되었습니다.";
 
+            case WELCOME:
+                WelcomePayload welcomePayload = (WelcomePayload) message.payload();
+                String welcomeText = welcomePayload.text();
+                return welcomeText.length() <= 15 ? welcomeText : welcomeText.substring(0, 15);
+
+            case TEXT:
             default:
                 TextPayload payload = (TextPayload) message.payload();
                 String text = payload.text();

--- a/src/main/java/com/mini/buting/api/matchRequest/controller/MatchRequestController.java
+++ b/src/main/java/com/mini/buting/api/matchRequest/controller/MatchRequestController.java
@@ -1,0 +1,82 @@
+package com.mini.buting.api.matchRequest.controller;
+
+import com.mini.buting.api.matchRequest.dto.request.MatchRequestRequestDto;
+import com.mini.buting.api.matchRequest.dto.response.MatchRequestResponseDto;
+import com.mini.buting.api.matchRequest.service.MatchRequestService;
+import com.mini.buting.global.response.BaseResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "MatchRequest", description = "팀 매칭 요청 API")
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/v1/match-requests")
+public class MatchRequestController {
+
+    private final MatchRequestService matchRequestService;
+
+    @Operation(summary = "매칭 요청 생성", description = "대상 팀에게 매칭 요청을 보냅니다.")
+    @PostMapping
+    public ResponseEntity<BaseResponse<MatchRequestResponseDto.MatchRequestCreateResponse>> createMatchRequest(
+            @Parameter(description = "사용자 ID", required = true)
+            @RequestHeader(value = "X-User-Id", required = false, defaultValue = "1") Long memberId,
+            @Valid @RequestBody MatchRequestRequestDto.CreateMatchRequest request
+    ) {
+        log.debug("매칭 요청 생성 - memberId: {}, targetTeamId: {}", memberId, request.targetTeamId());
+        MatchRequestResponseDto.MatchRequestCreateResponse response =
+                matchRequestService.createMatchRequest(memberId, request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(BaseResponse.onSuccess(response));
+    }
+
+    @Operation(summary = "매칭 요청 응답", description = "매칭 요청을 수락하거나 거절합니다.")
+    @PatchMapping("/{matchRequestId}/respond")
+    public ResponseEntity<BaseResponse<MatchRequestResponseDto.MatchRequestRespondResponse>> respondMatchRequest(
+            @Parameter(description = "사용자 ID", required = true)
+            @RequestHeader(value = "X-User-Id", required = false, defaultValue = "1") Long memberId,
+            @Parameter(description = "매칭 요청 ID", required = true)
+            @PathVariable Long matchRequestId,
+            @Valid @RequestBody MatchRequestRequestDto.RespondMatchRequest request
+    ) {
+        log.debug("매칭 요청 응답 - memberId: {}, matchRequestId: {}, accept: {}",
+                memberId, matchRequestId, request.accept());
+        MatchRequestResponseDto.MatchRequestRespondResponse response =
+                matchRequestService.respondMatchRequest(memberId, matchRequestId, request);
+        return ResponseEntity.ok(BaseResponse.onSuccess(response));
+    }
+
+    @Operation(summary = "매칭 요청 단건 조회", description = "매칭 요청 상세 정보를 조회합니다.")
+    @GetMapping("/{matchRequestId}")
+    public ResponseEntity<BaseResponse<MatchRequestResponseDto.MatchRequestDetailResponse>> getMatchRequest(
+            @Parameter(description = "사용자 ID", required = true)
+            @RequestHeader(value = "X-User-Id", required = false, defaultValue = "1") Long memberId,
+            @Parameter(description = "매칭 요청 ID", required = true)
+            @PathVariable Long matchRequestId
+    ) {
+        MatchRequestResponseDto.MatchRequestDetailResponse response =
+                matchRequestService.getMatchRequest(memberId, matchRequestId);
+        return ResponseEntity.ok(BaseResponse.onSuccess(response));
+    }
+
+    @Operation(summary = "매칭 요청 목록 조회", description = "보낸/받은 매칭 요청 목록을 조회합니다.")
+    @GetMapping
+    public ResponseEntity<BaseResponse<MatchRequestResponseDto.MatchRequestListResponse>> getMatchRequests(
+            @Parameter(description = "사용자 ID", required = true)
+            @RequestHeader(value = "X-User-Id", required = false, defaultValue = "1") Long memberId,
+            @Parameter(description = "sent | received", required = true)
+            @RequestParam String type,
+            @Parameter(description = "PENDING | ACCEPTED | REJECTED")
+            @RequestParam(required = false) String status
+    ) {
+        MatchRequestResponseDto.MatchRequestListResponse response =
+                matchRequestService.getMatchRequests(memberId, type, status);
+        return ResponseEntity.ok(BaseResponse.onSuccess(response));
+    }
+}

--- a/src/main/java/com/mini/buting/api/matchRequest/controller/MatchRequestController.java
+++ b/src/main/java/com/mini/buting/api/matchRequest/controller/MatchRequestController.java
@@ -26,57 +26,56 @@ public class MatchRequestController {
     @Operation(summary = "매칭 요청 생성", description = "대상 팀에게 매칭 요청을 보냅니다.")
     @PostMapping
     public ResponseEntity<BaseResponse<MatchRequestResponseDto.MatchRequestCreateResponse>> createMatchRequest(
-            @Parameter(description = "사용자 ID", required = true)
-            @RequestHeader(value = "X-User-Id", required = false, defaultValue = "1") Long memberId,
-            @Valid @RequestBody MatchRequestRequestDto.CreateMatchRequest request
-    ) {
+                    @Parameter(description = "사용자 ID", required = true)
+                    @RequestHeader(value = "X-User-Id", required = false, defaultValue = "1")
+                    Long memberId,
+                    @Valid @RequestBody MatchRequestRequestDto.CreateMatchRequest request) {
         log.debug("매칭 요청 생성 - memberId: {}, targetTeamId: {}", memberId, request.targetTeamId());
         MatchRequestResponseDto.MatchRequestCreateResponse response =
-                matchRequestService.createMatchRequest(memberId, request);
+                        matchRequestService.createMatchRequest(memberId, request);
         return ResponseEntity.status(HttpStatus.CREATED).body(BaseResponse.onSuccess(response));
     }
 
     @Operation(summary = "매칭 요청 응답", description = "매칭 요청을 수락하거나 거절합니다.")
     @PatchMapping("/{matchRequestId}/respond")
     public ResponseEntity<BaseResponse<MatchRequestResponseDto.MatchRequestRespondResponse>> respondMatchRequest(
-            @Parameter(description = "사용자 ID", required = true)
-            @RequestHeader(value = "X-User-Id", required = false, defaultValue = "1") Long memberId,
-            @Parameter(description = "매칭 요청 ID", required = true)
-            @PathVariable Long matchRequestId,
-            @Valid @RequestBody MatchRequestRequestDto.RespondMatchRequest request
-    ) {
-        log.debug("매칭 요청 응답 - memberId: {}, matchRequestId: {}, accept: {}",
-                memberId, matchRequestId, request.accept());
+                    @Parameter(description = "사용자 ID", required = true)
+                    @RequestHeader(value = "X-User-Id", required = false, defaultValue = "1")
+                    Long memberId,
+                    @Parameter(description = "매칭 요청 ID", required = true) @PathVariable
+                    Long matchRequestId,
+                    @Valid @RequestBody MatchRequestRequestDto.RespondMatchRequest request) {
+        log.debug("매칭 요청 응답 - memberId: {}, matchRequestId: {}, accept: {}", memberId,
+                        matchRequestId, request.accept());
         MatchRequestResponseDto.MatchRequestRespondResponse response =
-                matchRequestService.respondMatchRequest(memberId, matchRequestId, request);
+                        matchRequestService.respondMatchRequest(memberId, matchRequestId, request);
         return ResponseEntity.ok(BaseResponse.onSuccess(response));
     }
 
     @Operation(summary = "매칭 요청 단건 조회", description = "매칭 요청 상세 정보를 조회합니다.")
     @GetMapping("/{matchRequestId}")
     public ResponseEntity<BaseResponse<MatchRequestResponseDto.MatchRequestDetailResponse>> getMatchRequest(
-            @Parameter(description = "사용자 ID", required = true)
-            @RequestHeader(value = "X-User-Id", required = false, defaultValue = "1") Long memberId,
-            @Parameter(description = "매칭 요청 ID", required = true)
-            @PathVariable Long matchRequestId
-    ) {
+                    @Parameter(description = "사용자 ID", required = true)
+                    @RequestHeader(value = "X-User-Id", required = false, defaultValue = "1")
+                    Long memberId,
+                    @Parameter(description = "매칭 요청 ID", required = true) @PathVariable
+                    Long matchRequestId) {
         MatchRequestResponseDto.MatchRequestDetailResponse response =
-                matchRequestService.getMatchRequest(memberId, matchRequestId);
+                        matchRequestService.getMatchRequest(memberId, matchRequestId);
         return ResponseEntity.ok(BaseResponse.onSuccess(response));
     }
 
     @Operation(summary = "매칭 요청 목록 조회", description = "보낸/받은 매칭 요청 목록을 조회합니다.")
     @GetMapping
     public ResponseEntity<BaseResponse<MatchRequestResponseDto.MatchRequestListResponse>> getMatchRequests(
-            @Parameter(description = "사용자 ID", required = true)
-            @RequestHeader(value = "X-User-Id", required = false, defaultValue = "1") Long memberId,
-            @Parameter(description = "sent | received", required = true)
-            @RequestParam String type,
-            @Parameter(description = "PENDING | ACCEPTED | REJECTED")
-            @RequestParam(required = false) String status
-    ) {
+                    @Parameter(description = "사용자 ID", required = true)
+                    @RequestHeader(value = "X-User-Id", required = false, defaultValue = "1")
+                    Long memberId,
+                    @Parameter(description = "sent | received", required = true) @RequestParam
+                    String type, @Parameter(description = "PENDING | ACCEPTED | REJECTED")
+                    @RequestParam(required = false) String status) {
         MatchRequestResponseDto.MatchRequestListResponse response =
-                matchRequestService.getMatchRequests(memberId, type, status);
+                        matchRequestService.getMatchRequests(memberId, type, status);
         return ResponseEntity.ok(BaseResponse.onSuccess(response));
     }
 }

--- a/src/main/java/com/mini/buting/api/matchRequest/domain/MatchRequest.java
+++ b/src/main/java/com/mini/buting/api/matchRequest/domain/MatchRequest.java
@@ -86,7 +86,7 @@ public class MatchRequest extends BaseTimeEntity {
     }
 
     public void validateAcceptedStatus() {
-        if(status != MatchRequestStatus.ACCEPTED){
+        if (status != MatchRequestStatus.ACCEPTED) {
             throw new BaseException((BaseResponseStatus.MATCH_REQUEST_NOT_ACCEPTED));
         }
     }

--- a/src/main/java/com/mini/buting/api/matchRequest/dto/request/MatchRequestRequestDto.java
+++ b/src/main/java/com/mini/buting/api/matchRequest/dto/request/MatchRequestRequestDto.java
@@ -1,0 +1,21 @@
+package com.mini.buting.api.matchRequest.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+
+public class MatchRequestRequestDto {
+
+    @Builder
+    public record CreateMatchRequest(
+            @NotNull(message = "대상 팀 ID는 필수입니다.")
+            Long targetTeamId
+    ) {
+    }
+
+    @Builder
+    public record RespondMatchRequest(
+            @NotNull(message = "응답은 필수입니다.")
+            Boolean accept
+    ) {
+    }
+}

--- a/src/main/java/com/mini/buting/api/matchRequest/dto/request/MatchRequestRequestDto.java
+++ b/src/main/java/com/mini/buting/api/matchRequest/dto/request/MatchRequestRequestDto.java
@@ -6,16 +6,11 @@ import lombok.Builder;
 public class MatchRequestRequestDto {
 
     @Builder
-    public record CreateMatchRequest(
-            @NotNull(message = "대상 팀 ID는 필수입니다.")
-            Long targetTeamId
-    ) {
+    public record CreateMatchRequest(@NotNull(message = "대상 팀 ID는 필수입니다.") Long targetTeamId) {
     }
 
+
     @Builder
-    public record RespondMatchRequest(
-            @NotNull(message = "응답은 필수입니다.")
-            Boolean accept
-    ) {
+    public record RespondMatchRequest(@NotNull(message = "응답은 필수입니다.") Boolean accept) {
     }
 }

--- a/src/main/java/com/mini/buting/api/matchRequest/dto/response/MatchRequestResponseDto.java
+++ b/src/main/java/com/mini/buting/api/matchRequest/dto/response/MatchRequestResponseDto.java
@@ -11,68 +11,47 @@ import java.util.List;
 public class MatchRequestResponseDto {
 
     @Builder
-    public record MatchRequestCreateResponse(
-            Long matchRequestId,
-            String status,
-            Long requestTeamId,
-            Long targetTeamId,
-            @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
-            LocalDateTime createdAt
-    ) {
+    public record MatchRequestCreateResponse(Long matchRequestId, String status, Long requestTeamId,
+                                             Long targetTeamId,
+                                             @JsonFormat(shape = JsonFormat.Shape.STRING,
+                                                             pattern = "yyyy-MM-dd HH:mm:ss") LocalDateTime createdAt) {
     }
 
-    @Builder
-    public record MatchRequestRespondResponse(
-            Long matchRequestId,
-            String status,
-            Long chatRoomId,
-            @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
-            LocalDateTime updatedAt
-    ) {
-    }
 
     @Builder
-    public record MatchRequestDetailResponse(
-            Long matchRequestId,
-            String status,
-            TeamSummary requestTeam,
-            TeamSummary targetTeam,
-            @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
-            LocalDateTime createdAt,
-            @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
-            LocalDateTime updatedAt,
-            Boolean expired
-    ) {
+    public record MatchRequestRespondResponse(Long matchRequestId, String status, Long chatRoomId,
+                                              @JsonFormat(shape = JsonFormat.Shape.STRING,
+                                                              pattern = "yyyy-MM-dd HH:mm:ss") LocalDateTime updatedAt) {
     }
 
-    @Builder
-    public record MatchRequestSummary(
-            Long matchRequestId,
-            String status,
-            String requestedAtAgo,
-            String opponentTeamTitle,
-            TeamSize opponentTeamSize,
-            String opponentPreferredMood,
-            Integer opponentPreferredEntryYearMin,
-            Integer opponentPreferredEntryYearMax
-    ) {
-    }
 
     @Builder
-    public record MatchRequestListResponse(
-            List<MatchRequestSummary> requests,
-            Integer totalCount
-    ) {
+    public record MatchRequestDetailResponse(Long matchRequestId, String status,
+                                             TeamSummary requestTeam, TeamSummary targetTeam,
+                                             @JsonFormat(shape = JsonFormat.Shape.STRING,
+                                                             pattern = "yyyy-MM-dd HH:mm:ss") LocalDateTime createdAt,
+                                             @JsonFormat(shape = JsonFormat.Shape.STRING,
+                                                             pattern = "yyyy-MM-dd HH:mm:ss") LocalDateTime updatedAt,
+                                             Boolean expired) {
     }
 
+
     @Builder
-    public record TeamSummary(
-            Long teamId,
-            String title,
-            TeamSize teamSize,
-            Gender gender,
-            Integer currentMemberCount,
-            Integer targetMemberCount
-    ) {
+    public record MatchRequestSummary(Long matchRequestId, String status, String requestedAtAgo,
+                                      String opponentTeamTitle, TeamSize opponentTeamSize,
+                                      String opponentPreferredMood,
+                                      Integer opponentPreferredEntryYearMin,
+                                      Integer opponentPreferredEntryYearMax) {
+    }
+
+
+    @Builder
+    public record MatchRequestListResponse(List<MatchRequestSummary> requests, Integer totalCount) {
+    }
+
+
+    @Builder
+    public record TeamSummary(Long teamId, String title, TeamSize teamSize, Gender gender,
+                              Integer currentMemberCount, Integer targetMemberCount) {
     }
 }

--- a/src/main/java/com/mini/buting/api/matchRequest/dto/response/MatchRequestResponseDto.java
+++ b/src/main/java/com/mini/buting/api/matchRequest/dto/response/MatchRequestResponseDto.java
@@ -1,0 +1,76 @@
+package com.mini.buting.api.matchRequest.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.mini.buting.api.team.domain.Gender;
+import com.mini.buting.api.team.domain.TeamSize;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public class MatchRequestResponseDto {
+
+    @Builder
+    public record MatchRequestCreateResponse(
+            Long matchRequestId,
+            String status,
+            Long requestTeamId,
+            Long targetTeamId,
+            @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
+            LocalDateTime createdAt
+    ) {
+    }
+
+    @Builder
+    public record MatchRequestRespondResponse(
+            Long matchRequestId,
+            String status,
+            Long chatRoomId,
+            @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
+            LocalDateTime updatedAt
+    ) {
+    }
+
+    @Builder
+    public record MatchRequestDetailResponse(
+            Long matchRequestId,
+            String status,
+            TeamSummary requestTeam,
+            TeamSummary targetTeam,
+            @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
+            LocalDateTime createdAt,
+            @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
+            LocalDateTime updatedAt,
+            Boolean expired
+    ) {
+    }
+
+    @Builder
+    public record MatchRequestSummary(
+            Long matchRequestId,
+            String status,
+            TeamSummary requestTeam,
+            TeamSummary targetTeam,
+            @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
+            LocalDateTime createdAt
+    ) {
+    }
+
+    @Builder
+    public record MatchRequestListResponse(
+            List<MatchRequestSummary> requests,
+            Integer totalCount
+    ) {
+    }
+
+    @Builder
+    public record TeamSummary(
+            Long teamId,
+            String title,
+            TeamSize teamSize,
+            Gender gender,
+            Integer currentMemberCount,
+            Integer targetMemberCount
+    ) {
+    }
+}

--- a/src/main/java/com/mini/buting/api/matchRequest/dto/response/MatchRequestResponseDto.java
+++ b/src/main/java/com/mini/buting/api/matchRequest/dto/response/MatchRequestResponseDto.java
@@ -49,10 +49,12 @@ public class MatchRequestResponseDto {
     public record MatchRequestSummary(
             Long matchRequestId,
             String status,
-            TeamSummary requestTeam,
-            TeamSummary targetTeam,
-            @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
-            LocalDateTime createdAt
+            String requestedAtAgo,
+            String opponentTeamTitle,
+            TeamSize opponentTeamSize,
+            String opponentPreferredMood,
+            Integer opponentPreferredEntryYearMin,
+            Integer opponentPreferredEntryYearMax
     ) {
     }
 

--- a/src/main/java/com/mini/buting/api/matchRequest/repository/MatchRequestRepository.java
+++ b/src/main/java/com/mini/buting/api/matchRequest/repository/MatchRequestRepository.java
@@ -17,28 +17,28 @@ public interface MatchRequestRepository extends JpaRepository<MatchRequest, Long
     /**
      * 요청 팀/대상 팀 조합으로 특정 상태 요청 조회 (양방향)
      */
-    @Query("SELECT mr FROM MatchRequest mr " + "WHERE ((mr.requestTeam = :teamA AND mr.targetTeam = :teamB) " + "OR (mr.requestTeam = :teamB AND mr.targetTeam = :teamA)) " + "AND mr.status = :status")
+    @Query("SELECT mr FROM MatchRequest mr " + "WHERE ((mr.requestTeam = :teamA AND mr.targetTeam = :teamB) " + "OR (mr.requestTeam = :teamB AND mr.targetTeam = :teamA)) " + "AND mr.status = :status " + "AND mr.requestTeam.isDeleted = false AND mr.targetTeam.isDeleted = false")
     Optional<MatchRequest> findByTeamsAndStatus(@Param("teamA") Team teamA,
                     @Param("teamB") Team teamB, @Param("status") MatchRequestStatus status);
 
     /**
      * 요청 팀 기준 목록 조회 (최신순)
      */
-    @Query("SELECT mr FROM MatchRequest mr " + "JOIN FETCH mr.requestTeam " + "JOIN FETCH mr.targetTeam " + "WHERE mr.requestTeam = :requestTeam " + "ORDER BY mr.createdAt DESC")
+    @Query("SELECT mr FROM MatchRequest mr " + "JOIN FETCH mr.requestTeam " + "JOIN FETCH mr.targetTeam " + "WHERE mr.requestTeam = :requestTeam " + "AND mr.requestTeam.isDeleted = false AND mr.targetTeam.isDeleted = false " + "ORDER BY mr.createdAt DESC")
     List<MatchRequest> findByRequestTeamWithTeamsOrderByCreatedAtDesc(
                     @Param("requestTeam") Team requestTeam);
 
     /**
      * 대상 팀 기준 목록 조회 (최신순)
      */
-    @Query("SELECT mr FROM MatchRequest mr " + "JOIN FETCH mr.requestTeam " + "JOIN FETCH mr.targetTeam " + "WHERE mr.targetTeam = :targetTeam " + "ORDER BY mr.createdAt DESC")
+    @Query("SELECT mr FROM MatchRequest mr " + "JOIN FETCH mr.requestTeam " + "JOIN FETCH mr.targetTeam " + "WHERE mr.targetTeam = :targetTeam " + "AND mr.requestTeam.isDeleted = false AND mr.targetTeam.isDeleted = false " + "ORDER BY mr.createdAt DESC")
     List<MatchRequest> findByTargetTeamWithTeamsOrderByCreatedAtDesc(
                     @Param("targetTeam") Team targetTeam);
 
     /**
      * 요청 팀 + 상태 기준 목록 조회 (최신순)
      */
-    @Query("SELECT mr FROM MatchRequest mr " + "JOIN FETCH mr.requestTeam " + "JOIN FETCH mr.targetTeam " + "WHERE mr.requestTeam = :requestTeam " + "AND mr.status = :status " + "ORDER BY mr.createdAt DESC")
+    @Query("SELECT mr FROM MatchRequest mr " + "JOIN FETCH mr.requestTeam " + "JOIN FETCH mr.targetTeam " + "WHERE mr.requestTeam = :requestTeam " + "AND mr.status = :status " + "AND mr.requestTeam.isDeleted = false AND mr.targetTeam.isDeleted = false " + "ORDER BY mr.createdAt DESC")
     List<MatchRequest> findByRequestTeamAndStatusWithTeamsOrderByCreatedAtDesc(
                     @Param("requestTeam") Team requestTeam,
                     @Param("status") MatchRequestStatus status);
@@ -46,7 +46,7 @@ public interface MatchRequestRepository extends JpaRepository<MatchRequest, Long
     /**
      * 대상 팀 + 상태 기준 목록 조회 (최신순)
      */
-    @Query("SELECT mr FROM MatchRequest mr " + "JOIN FETCH mr.requestTeam " + "JOIN FETCH mr.targetTeam " + "WHERE mr.targetTeam = :targetTeam " + "AND mr.status = :status " + "ORDER BY mr.createdAt DESC")
+    @Query("SELECT mr FROM MatchRequest mr " + "JOIN FETCH mr.requestTeam " + "JOIN FETCH mr.targetTeam " + "WHERE mr.targetTeam = :targetTeam " + "AND mr.status = :status " + "AND mr.requestTeam.isDeleted = false AND mr.targetTeam.isDeleted = false " + "ORDER BY mr.createdAt DESC")
     List<MatchRequest> findByTargetTeamAndStatusWithTeamsOrderByCreatedAtDesc(
                     @Param("targetTeam") Team targetTeam,
                     @Param("status") MatchRequestStatus status);
@@ -54,13 +54,24 @@ public interface MatchRequestRepository extends JpaRepository<MatchRequest, Long
     /**
      * 관계자 접근 가능한 단건 조회 (요청팀/대상팀 권한 체크용)
      */
-    @Query("SELECT mr FROM MatchRequest mr " + "JOIN FETCH mr.requestTeam rt " + "JOIN FETCH mr.targetTeam tt " + "WHERE mr.id = :matchRequestId " + "AND (rt.id = :teamId OR tt.id = :teamId)")
+    @Query("SELECT mr FROM MatchRequest mr " + "JOIN FETCH mr.requestTeam rt " + "JOIN FETCH mr.targetTeam tt " + "WHERE mr.id = :matchRequestId " + "AND (rt.id = :teamId OR tt.id = :teamId) " + "AND rt.isDeleted = false AND tt.isDeleted = false")
     Optional<MatchRequest> findByIdAndTeamId(@Param("matchRequestId") Long matchRequestId,
                     @Param("teamId") Long teamId);
 
     /**
      * 상세 조회용 (팀 함께 로딩)
      */
-    @Query("SELECT mr FROM MatchRequest mr " + "JOIN FETCH mr.requestTeam " + "JOIN FETCH mr.targetTeam " + "WHERE mr.id = :matchRequestId")
+    @Query("SELECT mr FROM MatchRequest mr " + "JOIN FETCH mr.requestTeam " + "JOIN FETCH mr.targetTeam " + "WHERE mr.id = :matchRequestId " + "AND mr.requestTeam.isDeleted = false AND mr.targetTeam.isDeleted = false")
     Optional<MatchRequest> findByIdWithTeams(@Param("matchRequestId") Long matchRequestId);
+
+    /**
+     * 해당 팀이 매칭 성사(ACCEPTED)된 적이 있는지 확인 (요청/대상 양방향)
+     */
+    @Query("""
+                    SELECT CASE WHEN COUNT(mr) > 0 THEN true ELSE false END
+                    FROM MatchRequest mr
+                    WHERE mr.status = 'ACCEPTED'
+                      AND (mr.requestTeam.id = :teamId OR mr.targetTeam.id = :teamId)
+                    """)
+    boolean existsAcceptedByTeamId(@Param("teamId") Long teamId);
 }

--- a/src/main/java/com/mini/buting/api/matchRequest/repository/MatchRequestRepository.java
+++ b/src/main/java/com/mini/buting/api/matchRequest/repository/MatchRequestRepository.java
@@ -30,27 +30,53 @@ public interface MatchRequestRepository extends JpaRepository<MatchRequest, Long
     /**
      * 요청 팀 기준 목록 조회 (최신순)
      */
-    List<MatchRequest> findByRequestTeamOrderByCreatedAtDesc(Team requestTeam);
+    @Query("SELECT mr FROM MatchRequest mr " +
+            "JOIN FETCH mr.requestTeam " +
+            "JOIN FETCH mr.targetTeam " +
+            "WHERE mr.requestTeam = :requestTeam " +
+            "ORDER BY mr.createdAt DESC")
+    List<MatchRequest> findByRequestTeamWithTeamsOrderByCreatedAtDesc(
+            @Param("requestTeam") Team requestTeam
+    );
 
     /**
      * 대상 팀 기준 목록 조회 (최신순)
      */
-    List<MatchRequest> findByTargetTeamOrderByCreatedAtDesc(Team targetTeam);
+    @Query("SELECT mr FROM MatchRequest mr " +
+            "JOIN FETCH mr.requestTeam " +
+            "JOIN FETCH mr.targetTeam " +
+            "WHERE mr.targetTeam = :targetTeam " +
+            "ORDER BY mr.createdAt DESC")
+    List<MatchRequest> findByTargetTeamWithTeamsOrderByCreatedAtDesc(
+            @Param("targetTeam") Team targetTeam
+    );
 
     /**
      * 요청 팀 + 상태 기준 목록 조회 (최신순)
      */
-    List<MatchRequest> findByRequestTeamAndStatusOrderByCreatedAtDesc(
-            Team requestTeam,
-            MatchRequestStatus status
+    @Query("SELECT mr FROM MatchRequest mr " +
+            "JOIN FETCH mr.requestTeam " +
+            "JOIN FETCH mr.targetTeam " +
+            "WHERE mr.requestTeam = :requestTeam " +
+            "AND mr.status = :status " +
+            "ORDER BY mr.createdAt DESC")
+    List<MatchRequest> findByRequestTeamAndStatusWithTeamsOrderByCreatedAtDesc(
+            @Param("requestTeam") Team requestTeam,
+            @Param("status") MatchRequestStatus status
     );
 
     /**
      * 대상 팀 + 상태 기준 목록 조회 (최신순)
      */
-    List<MatchRequest> findByTargetTeamAndStatusOrderByCreatedAtDesc(
-            Team targetTeam,
-            MatchRequestStatus status
+    @Query("SELECT mr FROM MatchRequest mr " +
+            "JOIN FETCH mr.requestTeam " +
+            "JOIN FETCH mr.targetTeam " +
+            "WHERE mr.targetTeam = :targetTeam " +
+            "AND mr.status = :status " +
+            "ORDER BY mr.createdAt DESC")
+    List<MatchRequest> findByTargetTeamAndStatusWithTeamsOrderByCreatedAtDesc(
+            @Param("targetTeam") Team targetTeam,
+            @Param("status") MatchRequestStatus status
     );
 
     /**

--- a/src/main/java/com/mini/buting/api/matchRequest/repository/MatchRequestRepository.java
+++ b/src/main/java/com/mini/buting/api/matchRequest/repository/MatchRequestRepository.java
@@ -17,87 +17,50 @@ public interface MatchRequestRepository extends JpaRepository<MatchRequest, Long
     /**
      * 요청 팀/대상 팀 조합으로 특정 상태 요청 조회 (양방향)
      */
-    @Query("SELECT mr FROM MatchRequest mr " +
-            "WHERE ((mr.requestTeam = :teamA AND mr.targetTeam = :teamB) " +
-            "OR (mr.requestTeam = :teamB AND mr.targetTeam = :teamA)) " +
-            "AND mr.status = :status")
-    Optional<MatchRequest> findByTeamsAndStatus(
-            @Param("teamA") Team teamA,
-            @Param("teamB") Team teamB,
-            @Param("status") MatchRequestStatus status
-    );
+    @Query("SELECT mr FROM MatchRequest mr " + "WHERE ((mr.requestTeam = :teamA AND mr.targetTeam = :teamB) " + "OR (mr.requestTeam = :teamB AND mr.targetTeam = :teamA)) " + "AND mr.status = :status")
+    Optional<MatchRequest> findByTeamsAndStatus(@Param("teamA") Team teamA,
+                    @Param("teamB") Team teamB, @Param("status") MatchRequestStatus status);
 
     /**
      * 요청 팀 기준 목록 조회 (최신순)
      */
-    @Query("SELECT mr FROM MatchRequest mr " +
-            "JOIN FETCH mr.requestTeam " +
-            "JOIN FETCH mr.targetTeam " +
-            "WHERE mr.requestTeam = :requestTeam " +
-            "ORDER BY mr.createdAt DESC")
+    @Query("SELECT mr FROM MatchRequest mr " + "JOIN FETCH mr.requestTeam " + "JOIN FETCH mr.targetTeam " + "WHERE mr.requestTeam = :requestTeam " + "ORDER BY mr.createdAt DESC")
     List<MatchRequest> findByRequestTeamWithTeamsOrderByCreatedAtDesc(
-            @Param("requestTeam") Team requestTeam
-    );
+                    @Param("requestTeam") Team requestTeam);
 
     /**
      * 대상 팀 기준 목록 조회 (최신순)
      */
-    @Query("SELECT mr FROM MatchRequest mr " +
-            "JOIN FETCH mr.requestTeam " +
-            "JOIN FETCH mr.targetTeam " +
-            "WHERE mr.targetTeam = :targetTeam " +
-            "ORDER BY mr.createdAt DESC")
+    @Query("SELECT mr FROM MatchRequest mr " + "JOIN FETCH mr.requestTeam " + "JOIN FETCH mr.targetTeam " + "WHERE mr.targetTeam = :targetTeam " + "ORDER BY mr.createdAt DESC")
     List<MatchRequest> findByTargetTeamWithTeamsOrderByCreatedAtDesc(
-            @Param("targetTeam") Team targetTeam
-    );
+                    @Param("targetTeam") Team targetTeam);
 
     /**
      * 요청 팀 + 상태 기준 목록 조회 (최신순)
      */
-    @Query("SELECT mr FROM MatchRequest mr " +
-            "JOIN FETCH mr.requestTeam " +
-            "JOIN FETCH mr.targetTeam " +
-            "WHERE mr.requestTeam = :requestTeam " +
-            "AND mr.status = :status " +
-            "ORDER BY mr.createdAt DESC")
+    @Query("SELECT mr FROM MatchRequest mr " + "JOIN FETCH mr.requestTeam " + "JOIN FETCH mr.targetTeam " + "WHERE mr.requestTeam = :requestTeam " + "AND mr.status = :status " + "ORDER BY mr.createdAt DESC")
     List<MatchRequest> findByRequestTeamAndStatusWithTeamsOrderByCreatedAtDesc(
-            @Param("requestTeam") Team requestTeam,
-            @Param("status") MatchRequestStatus status
-    );
+                    @Param("requestTeam") Team requestTeam,
+                    @Param("status") MatchRequestStatus status);
 
     /**
      * 대상 팀 + 상태 기준 목록 조회 (최신순)
      */
-    @Query("SELECT mr FROM MatchRequest mr " +
-            "JOIN FETCH mr.requestTeam " +
-            "JOIN FETCH mr.targetTeam " +
-            "WHERE mr.targetTeam = :targetTeam " +
-            "AND mr.status = :status " +
-            "ORDER BY mr.createdAt DESC")
+    @Query("SELECT mr FROM MatchRequest mr " + "JOIN FETCH mr.requestTeam " + "JOIN FETCH mr.targetTeam " + "WHERE mr.targetTeam = :targetTeam " + "AND mr.status = :status " + "ORDER BY mr.createdAt DESC")
     List<MatchRequest> findByTargetTeamAndStatusWithTeamsOrderByCreatedAtDesc(
-            @Param("targetTeam") Team targetTeam,
-            @Param("status") MatchRequestStatus status
-    );
+                    @Param("targetTeam") Team targetTeam,
+                    @Param("status") MatchRequestStatus status);
 
     /**
      * 관계자 접근 가능한 단건 조회 (요청팀/대상팀 권한 체크용)
      */
-    @Query("SELECT mr FROM MatchRequest mr " +
-            "JOIN FETCH mr.requestTeam rt " +
-            "JOIN FETCH mr.targetTeam tt " +
-            "WHERE mr.id = :matchRequestId " +
-            "AND (rt.id = :teamId OR tt.id = :teamId)")
-    Optional<MatchRequest> findByIdAndTeamId(
-            @Param("matchRequestId") Long matchRequestId,
-            @Param("teamId") Long teamId
-    );
+    @Query("SELECT mr FROM MatchRequest mr " + "JOIN FETCH mr.requestTeam rt " + "JOIN FETCH mr.targetTeam tt " + "WHERE mr.id = :matchRequestId " + "AND (rt.id = :teamId OR tt.id = :teamId)")
+    Optional<MatchRequest> findByIdAndTeamId(@Param("matchRequestId") Long matchRequestId,
+                    @Param("teamId") Long teamId);
 
     /**
      * 상세 조회용 (팀 함께 로딩)
      */
-    @Query("SELECT mr FROM MatchRequest mr " +
-            "JOIN FETCH mr.requestTeam " +
-            "JOIN FETCH mr.targetTeam " +
-            "WHERE mr.id = :matchRequestId")
+    @Query("SELECT mr FROM MatchRequest mr " + "JOIN FETCH mr.requestTeam " + "JOIN FETCH mr.targetTeam " + "WHERE mr.id = :matchRequestId")
     Optional<MatchRequest> findByIdWithTeams(@Param("matchRequestId") Long matchRequestId);
 }

--- a/src/main/java/com/mini/buting/api/matchRequest/repository/MatchRequestRepository.java
+++ b/src/main/java/com/mini/buting/api/matchRequest/repository/MatchRequestRepository.java
@@ -1,9 +1,77 @@
 package com.mini.buting.api.matchRequest.repository;
 
 import com.mini.buting.api.matchRequest.domain.MatchRequest;
+import com.mini.buting.api.matchRequest.domain.MatchRequest.MatchRequestStatus;
+import com.mini.buting.api.team.domain.Team;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface MatchRequestRepository extends JpaRepository<MatchRequest, Long> {
+
+    /**
+     * 요청 팀/대상 팀 조합으로 특정 상태 요청 조회 (양방향)
+     */
+    @Query("SELECT mr FROM MatchRequest mr " +
+            "WHERE ((mr.requestTeam = :teamA AND mr.targetTeam = :teamB) " +
+            "OR (mr.requestTeam = :teamB AND mr.targetTeam = :teamA)) " +
+            "AND mr.status = :status")
+    Optional<MatchRequest> findByTeamsAndStatus(
+            @Param("teamA") Team teamA,
+            @Param("teamB") Team teamB,
+            @Param("status") MatchRequestStatus status
+    );
+
+    /**
+     * 요청 팀 기준 목록 조회 (최신순)
+     */
+    List<MatchRequest> findByRequestTeamOrderByCreatedAtDesc(Team requestTeam);
+
+    /**
+     * 대상 팀 기준 목록 조회 (최신순)
+     */
+    List<MatchRequest> findByTargetTeamOrderByCreatedAtDesc(Team targetTeam);
+
+    /**
+     * 요청 팀 + 상태 기준 목록 조회 (최신순)
+     */
+    List<MatchRequest> findByRequestTeamAndStatusOrderByCreatedAtDesc(
+            Team requestTeam,
+            MatchRequestStatus status
+    );
+
+    /**
+     * 대상 팀 + 상태 기준 목록 조회 (최신순)
+     */
+    List<MatchRequest> findByTargetTeamAndStatusOrderByCreatedAtDesc(
+            Team targetTeam,
+            MatchRequestStatus status
+    );
+
+    /**
+     * 관계자 접근 가능한 단건 조회 (요청팀/대상팀 권한 체크용)
+     */
+    @Query("SELECT mr FROM MatchRequest mr " +
+            "JOIN FETCH mr.requestTeam rt " +
+            "JOIN FETCH mr.targetTeam tt " +
+            "WHERE mr.id = :matchRequestId " +
+            "AND (rt.id = :teamId OR tt.id = :teamId)")
+    Optional<MatchRequest> findByIdAndTeamId(
+            @Param("matchRequestId") Long matchRequestId,
+            @Param("teamId") Long teamId
+    );
+
+    /**
+     * 상세 조회용 (팀 함께 로딩)
+     */
+    @Query("SELECT mr FROM MatchRequest mr " +
+            "JOIN FETCH mr.requestTeam " +
+            "JOIN FETCH mr.targetTeam " +
+            "WHERE mr.id = :matchRequestId")
+    Optional<MatchRequest> findByIdWithTeams(@Param("matchRequestId") Long matchRequestId);
 }

--- a/src/main/java/com/mini/buting/api/matchRequest/service/MatchRequestService.java
+++ b/src/main/java/com/mini/buting/api/matchRequest/service/MatchRequestService.java
@@ -197,21 +197,23 @@ public class MatchRequestService {
         if ("sent".equalsIgnoreCase(type)) {
             // 보낸 요청 목록
             requests = parsedStatus == null ?
-                    matchRequestRepository.findByRequestTeamOrderByCreatedAtDesc(leaderTeam) :
-                    matchRequestRepository.findByRequestTeamAndStatusOrderByCreatedAtDesc(
+                    matchRequestRepository.findByRequestTeamWithTeamsOrderByCreatedAtDesc(
+                            leaderTeam) :
+                    matchRequestRepository.findByRequestTeamAndStatusWithTeamsOrderByCreatedAtDesc(
                             leaderTeam, parsedStatus);
         } else if ("received".equalsIgnoreCase(type)) {
             // 받은 요청 목록
             requests = parsedStatus == null ?
-                    matchRequestRepository.findByTargetTeamOrderByCreatedAtDesc(leaderTeam) :
-                    matchRequestRepository.findByTargetTeamAndStatusOrderByCreatedAtDesc(
+                    matchRequestRepository.findByTargetTeamWithTeamsOrderByCreatedAtDesc(
+                            leaderTeam) :
+                    matchRequestRepository.findByTargetTeamAndStatusWithTeamsOrderByCreatedAtDesc(
                             leaderTeam, parsedStatus);
         } else {
             throw new BaseException(BaseResponseStatus.INVALID_REQUEST);
         }
 
         List<MatchRequestResponseDto.MatchRequestSummary> summaries = requests.stream()
-                .map(this::toSummary)
+                .map(matchRequest -> toSummary(matchRequest, type))
                 .toList();
 
         return MatchRequestResponseDto.MatchRequestListResponse.builder()
@@ -220,13 +222,22 @@ public class MatchRequestService {
                 .build();
     }
 
-    private MatchRequestResponseDto.MatchRequestSummary toSummary(MatchRequest matchRequest) {
+    private MatchRequestResponseDto.MatchRequestSummary toSummary(
+            MatchRequest matchRequest,
+            String type
+    ) {
+        Team opponentTeam = "received".equalsIgnoreCase(type)
+                ? matchRequest.getRequestTeam()
+                : matchRequest.getTargetTeam();
         return MatchRequestResponseDto.MatchRequestSummary.builder()
                 .matchRequestId(matchRequest.getId())
                 .status(matchRequest.getStatus().name())
-                .requestTeam(toTeamSummary(matchRequest.getRequestTeam()))
-                .targetTeam(toTeamSummary(matchRequest.getTargetTeam()))
-                .createdAt(matchRequest.getCreatedAt())
+                .requestedAtAgo(formatTimeAgo(matchRequest.getCreatedAt()))
+                .opponentTeamTitle(opponentTeam.getTitle())
+                .opponentTeamSize(opponentTeam.getTeamSize())
+                .opponentPreferredMood(opponentTeam.getPreferredMood().getDisplayName())
+                .opponentPreferredEntryYearMin(opponentTeam.getPreferredEntryYearMin().intValue())
+                .opponentPreferredEntryYearMax(opponentTeam.getPreferredEntryYearMax().intValue())
                 .build();
     }
 
@@ -259,6 +270,21 @@ public class MatchRequestService {
         // 활성 회원 조회
         return memberRepository.findById(memberId)
                 .orElseThrow(() -> new BaseException(BaseResponseStatus.MEMBER_NOT_FOUND));
+    }
+
+    private String formatTimeAgo(java.time.LocalDateTime createdAt) {
+        java.time.Duration duration = java.time.Duration.between(createdAt,
+                java.time.LocalDateTime.now());
+        long minutes = duration.toMinutes();
+        if (minutes < 60) {
+            return minutes + "분 전";
+        }
+        long hours = duration.toHours();
+        if (hours < 24) {
+            return hours + "시간 전";
+        }
+        long days = duration.toDays();
+        return days + "일 전";
     }
 
     private void validateTeamReady(Team team) {

--- a/src/main/java/com/mini/buting/api/matchRequest/service/MatchRequestService.java
+++ b/src/main/java/com/mini/buting/api/matchRequest/service/MatchRequestService.java
@@ -37,23 +37,21 @@ public class MatchRequestService {
     private final ChatRoomService chatRoomService;
 
     @Transactional
-    public MatchRequestResponseDto.MatchRequestCreateResponse createMatchRequest(
-            Long memberId,
-            MatchRequestRequestDto.CreateMatchRequest request
-    ) {
+    public MatchRequestResponseDto.MatchRequestCreateResponse createMatchRequest(Long memberId,
+                    MatchRequestRequestDto.CreateMatchRequest request) {
         // 요청자 조회
         Member member = getMember(memberId);
 
         // 요청 팀은 팀장 기준으로 식별
         Team requestTeam = teamRepository.findByLeader(member)
-                .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_TEAM_LEADER));
+                        .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_TEAM_LEADER));
 
         // 매칭 가능한 상태인지 확인
         validateTeamReady(requestTeam);
 
         // 대상 팀 조회
         Team targetTeam = teamRepository.findById(request.targetTeamId())
-                .orElseThrow(() -> new BaseException(BaseResponseStatus.TEAM_NOT_FOUND));
+                        .orElseThrow(() -> new BaseException(BaseResponseStatus.TEAM_NOT_FOUND));
 
         // 자기 팀으로는 요청 불가
         if (requestTeam.getId().equals(targetTeam.getId())) {
@@ -70,12 +68,12 @@ public class MatchRequestService {
 
         // 기존 요청(대기/수락) 중복 방지
         if (matchRequestRepository.findByTeamsAndStatus(requestTeam, targetTeam,
-                MatchRequestStatus.PENDING).isPresent()) {
+                        MatchRequestStatus.PENDING).isPresent()) {
             throw new BaseException(BaseResponseStatus.MATCH_REQUEST_ALREADY_EXISTS);
         }
 
         if (matchRequestRepository.findByTeamsAndStatus(requestTeam, targetTeam,
-                MatchRequestStatus.ACCEPTED).isPresent()) {
+                        MatchRequestStatus.ACCEPTED).isPresent()) {
             throw new BaseException(BaseResponseStatus.MATCH_REQUEST_ALREADY_EXISTS);
         }
 
@@ -88,36 +86,30 @@ public class MatchRequestService {
         }
 
         // 매칭 요청 생성
-        MatchRequest matchRequest = MatchRequest.builder()
-                .requestTeam(requestTeam)
-                .targetTeam(targetTeam)
-                .build();
+        MatchRequest matchRequest =
+                        MatchRequest.builder().requestTeam(requestTeam).targetTeam(targetTeam)
+                                        .build();
 
         MatchRequest saved = matchRequestRepository.save(matchRequest);
 
         return MatchRequestResponseDto.MatchRequestCreateResponse.builder()
-                .matchRequestId(saved.getId())
-                .status(saved.getStatus().name())
-                .requestTeamId(requestTeam.getId())
-                .targetTeamId(targetTeam.getId())
-                .createdAt(saved.getCreatedAt())
-                .build();
+                        .matchRequestId(saved.getId()).status(saved.getStatus().name())
+                        .requestTeamId(requestTeam.getId()).targetTeamId(targetTeam.getId())
+                        .createdAt(saved.getCreatedAt()).build();
     }
 
     @Transactional
-    public MatchRequestResponseDto.MatchRequestRespondResponse respondMatchRequest(
-            Long memberId,
-            Long matchRequestId,
-            MatchRequestRequestDto.RespondMatchRequest request
-    ) {
+    public MatchRequestResponseDto.MatchRequestRespondResponse respondMatchRequest(Long memberId,
+                    Long matchRequestId, MatchRequestRequestDto.RespondMatchRequest request) {
         // 응답자(대상 팀 리더) 확인
         Member member = getMember(memberId);
         Team leaderTeam = teamRepository.findByLeader(member)
-                .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_TEAM_LEADER));
+                        .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_TEAM_LEADER));
 
         // 요청 및 연관 팀 로딩
         MatchRequest matchRequest = matchRequestRepository.findByIdWithTeams(matchRequestId)
-                .orElseThrow(() -> new BaseException(BaseResponseStatus.MATCH_REQUEST_NOT_FOUND));
+                        .orElseThrow(() -> new BaseException(
+                                        BaseResponseStatus.MATCH_REQUEST_NOT_FOUND));
 
         // 대상 팀 리더만 응답 가능
         if (!leaderTeam.getId().equals(matchRequest.getTargetTeam().getId())) {
@@ -128,8 +120,8 @@ public class MatchRequestService {
         matchRequest.expireIfNeeded();
         if (!matchRequest.canBeProcessed()) {
             throw new BaseException(matchRequest.isExpired() ?
-                    BaseResponseStatus.MATCH_REQUEST_EXPIRED :
-                    BaseResponseStatus.MATCH_REQUEST_NOT_PENDING);
+                            BaseResponseStatus.MATCH_REQUEST_EXPIRED :
+                            BaseResponseStatus.MATCH_REQUEST_NOT_PENDING);
         }
 
         Long chatRoomId = null;
@@ -148,47 +140,40 @@ public class MatchRequestService {
         }
 
         return MatchRequestResponseDto.MatchRequestRespondResponse.builder()
-                .matchRequestId(matchRequest.getId())
-                .status(matchRequest.getStatus().name())
-                .chatRoomId(chatRoomId)
-                .updatedAt(matchRequest.getUpdatedAt())
-                .build();
+                        .matchRequestId(matchRequest.getId())
+                        .status(matchRequest.getStatus().name()).chatRoomId(chatRoomId)
+                        .updatedAt(matchRequest.getUpdatedAt()).build();
     }
 
-    public MatchRequestResponseDto.MatchRequestDetailResponse getMatchRequest(
-            Long memberId,
-            Long matchRequestId
-    ) {
+    public MatchRequestResponseDto.MatchRequestDetailResponse getMatchRequest(Long memberId,
+                    Long matchRequestId) {
         // 요청자 팀(리더) 기준 권한 확인
         Member member = getMember(memberId);
         Team leaderTeam = teamRepository.findByLeader(member)
-                .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_TEAM_LEADER));
+                        .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_TEAM_LEADER));
 
         // 요청 팀 또는 대상 팀만 조회 가능
-        MatchRequest matchRequest = matchRequestRepository.findByIdAndTeamId(
-                        matchRequestId, leaderTeam.getId())
-                .orElseThrow(() -> new BaseException(BaseResponseStatus.MATCH_REQUEST_NOT_FOUND));
+        MatchRequest matchRequest =
+                        matchRequestRepository.findByIdAndTeamId(matchRequestId, leaderTeam.getId())
+                                        .orElseThrow(() -> new BaseException(
+                                                        BaseResponseStatus.MATCH_REQUEST_NOT_FOUND));
 
         return MatchRequestResponseDto.MatchRequestDetailResponse.builder()
-                .matchRequestId(matchRequest.getId())
-                .status(matchRequest.getStatus().name())
-                .requestTeam(toTeamSummary(matchRequest.getRequestTeam()))
-                .targetTeam(toTeamSummary(matchRequest.getTargetTeam()))
-                .createdAt(matchRequest.getCreatedAt())
-                .updatedAt(matchRequest.getUpdatedAt())
-                .expired(matchRequest.isExpired())
-                .build();
+                        .matchRequestId(matchRequest.getId())
+                        .status(matchRequest.getStatus().name())
+                        .requestTeam(toTeamSummary(matchRequest.getRequestTeam()))
+                        .targetTeam(toTeamSummary(matchRequest.getTargetTeam()))
+                        .createdAt(matchRequest.getCreatedAt())
+                        .updatedAt(matchRequest.getUpdatedAt()).expired(matchRequest.isExpired())
+                        .build();
     }
 
-    public MatchRequestResponseDto.MatchRequestListResponse getMatchRequests(
-            Long memberId,
-            String type,
-            String status
-    ) {
+    public MatchRequestResponseDto.MatchRequestListResponse getMatchRequests(Long memberId,
+                    String type, String status) {
         // 팀 리더 기준 목록 조회
         Member member = getMember(memberId);
         Team leaderTeam = teamRepository.findByLeader(member)
-                .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_TEAM_LEADER));
+                        .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_TEAM_LEADER));
 
         // 상태 파라미터 파싱
         MatchRequestStatus parsedStatus = parseStatus(status);
@@ -197,61 +182,54 @@ public class MatchRequestService {
         if ("sent".equalsIgnoreCase(type)) {
             // 보낸 요청 목록
             requests = parsedStatus == null ?
-                    matchRequestRepository.findByRequestTeamWithTeamsOrderByCreatedAtDesc(
-                            leaderTeam) :
-                    matchRequestRepository.findByRequestTeamAndStatusWithTeamsOrderByCreatedAtDesc(
-                            leaderTeam, parsedStatus);
+                            matchRequestRepository.findByRequestTeamWithTeamsOrderByCreatedAtDesc(
+                                            leaderTeam) :
+                            matchRequestRepository.findByRequestTeamAndStatusWithTeamsOrderByCreatedAtDesc(
+                                            leaderTeam, parsedStatus);
         } else if ("received".equalsIgnoreCase(type)) {
             // 받은 요청 목록
             requests = parsedStatus == null ?
-                    matchRequestRepository.findByTargetTeamWithTeamsOrderByCreatedAtDesc(
-                            leaderTeam) :
-                    matchRequestRepository.findByTargetTeamAndStatusWithTeamsOrderByCreatedAtDesc(
-                            leaderTeam, parsedStatus);
+                            matchRequestRepository.findByTargetTeamWithTeamsOrderByCreatedAtDesc(
+                                            leaderTeam) :
+                            matchRequestRepository.findByTargetTeamAndStatusWithTeamsOrderByCreatedAtDesc(
+                                            leaderTeam, parsedStatus);
         } else {
             throw new BaseException(BaseResponseStatus.INVALID_REQUEST);
         }
 
-        List<MatchRequestResponseDto.MatchRequestSummary> summaries = requests.stream()
-                .map(matchRequest -> toSummary(matchRequest, type))
-                .toList();
+        List<MatchRequestResponseDto.MatchRequestSummary> summaries =
+                        requests.stream().map(matchRequest -> toSummary(matchRequest, type))
+                                        .toList();
 
-        return MatchRequestResponseDto.MatchRequestListResponse.builder()
-                .requests(summaries)
-                .totalCount(summaries.size())
-                .build();
+        return MatchRequestResponseDto.MatchRequestListResponse.builder().requests(summaries)
+                        .totalCount(summaries.size()).build();
     }
 
-    private MatchRequestResponseDto.MatchRequestSummary toSummary(
-            MatchRequest matchRequest,
-            String type
-    ) {
-        Team opponentTeam = "received".equalsIgnoreCase(type)
-                ? matchRequest.getRequestTeam()
-                : matchRequest.getTargetTeam();
+    private MatchRequestResponseDto.MatchRequestSummary toSummary(MatchRequest matchRequest,
+                    String type) {
+        Team opponentTeam = "received".equalsIgnoreCase(type) ?
+                        matchRequest.getRequestTeam() :
+                        matchRequest.getTargetTeam();
         return MatchRequestResponseDto.MatchRequestSummary.builder()
-                .matchRequestId(matchRequest.getId())
-                .status(matchRequest.getStatus().name())
-                .requestedAtAgo(formatTimeAgo(matchRequest.getCreatedAt()))
-                .opponentTeamTitle(opponentTeam.getTitle())
-                .opponentTeamSize(opponentTeam.getTeamSize())
-                .opponentPreferredMood(opponentTeam.getPreferredMood().getDisplayName())
-                .opponentPreferredEntryYearMin(opponentTeam.getPreferredEntryYearMin().intValue())
-                .opponentPreferredEntryYearMax(opponentTeam.getPreferredEntryYearMax().intValue())
-                .build();
+                        .matchRequestId(matchRequest.getId())
+                        .status(matchRequest.getStatus().name())
+                        .requestedAtAgo(formatTimeAgo(matchRequest.getCreatedAt()))
+                        .opponentTeamTitle(opponentTeam.getTitle())
+                        .opponentTeamSize(opponentTeam.getTeamSize())
+                        .opponentPreferredMood(opponentTeam.getPreferredMood().getDisplayName())
+                        .opponentPreferredEntryYearMin(
+                                        opponentTeam.getPreferredEntryYearMin().intValue())
+                        .opponentPreferredEntryYearMax(
+                                        opponentTeam.getPreferredEntryYearMax().intValue()).build();
     }
 
     private MatchRequestResponseDto.TeamSummary toTeamSummary(Team team) {
         // 현재 인원은 TeamMember 기준 카운트
         int currentMemberCount = (int) teamMemberRepository.countByTeam(team);
-        return MatchRequestResponseDto.TeamSummary.builder()
-                .teamId(team.getId())
-                .title(team.getTitle())
-                .teamSize(team.getTeamSize())
-                .gender(team.getGender())
-                .currentMemberCount(currentMemberCount)
-                .targetMemberCount(team.getTeamSize().getSize())
-                .build();
+        return MatchRequestResponseDto.TeamSummary.builder().teamId(team.getId())
+                        .title(team.getTitle()).teamSize(team.getTeamSize())
+                        .gender(team.getGender()).currentMemberCount(currentMemberCount)
+                        .targetMemberCount(team.getTeamSize().getSize()).build();
     }
 
     private MatchRequestStatus parseStatus(String status) {
@@ -269,12 +247,12 @@ public class MatchRequestService {
     private Member getMember(Long memberId) {
         // 활성 회원 조회
         return memberRepository.findById(memberId)
-                .orElseThrow(() -> new BaseException(BaseResponseStatus.MEMBER_NOT_FOUND));
+                        .orElseThrow(() -> new BaseException(BaseResponseStatus.MEMBER_NOT_FOUND));
     }
 
     private String formatTimeAgo(java.time.LocalDateTime createdAt) {
-        java.time.Duration duration = java.time.Duration.between(createdAt,
-                java.time.LocalDateTime.now());
+        java.time.Duration duration =
+                        java.time.Duration.between(createdAt, java.time.LocalDateTime.now());
         long minutes = duration.toMinutes();
         if (minutes < 60) {
             return minutes + "분 전";

--- a/src/main/java/com/mini/buting/api/matchRequest/service/MatchRequestService.java
+++ b/src/main/java/com/mini/buting/api/matchRequest/service/MatchRequestService.java
@@ -1,0 +1,270 @@
+package com.mini.buting.api.matchRequest.service;
+
+import com.mini.buting.api.chat.domain.chatroom.ChatRoom;
+import com.mini.buting.api.chat.repository.ChatRoomRepository;
+import com.mini.buting.api.chat.service.ChatRoomService;
+import com.mini.buting.api.matchRequest.domain.MatchRequest;
+import com.mini.buting.api.matchRequest.domain.MatchRequest.MatchRequestStatus;
+import com.mini.buting.api.matchRequest.dto.request.MatchRequestRequestDto;
+import com.mini.buting.api.matchRequest.dto.response.MatchRequestResponseDto;
+import com.mini.buting.api.matchRequest.repository.MatchRequestRepository;
+import com.mini.buting.api.member.domain.Member;
+import com.mini.buting.api.member.repository.MemberRepository;
+import com.mini.buting.api.team.domain.Gender;
+import com.mini.buting.api.team.domain.Team;
+import com.mini.buting.api.team.repository.TeamMemberRepository;
+import com.mini.buting.api.team.repository.TeamRepository;
+import com.mini.buting.global.exception.BaseException;
+import com.mini.buting.global.response.BaseResponseStatus;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+@Transactional(readOnly = true)
+public class MatchRequestService {
+
+    private final MatchRequestRepository matchRequestRepository;
+    private final TeamRepository teamRepository;
+    private final TeamMemberRepository teamMemberRepository;
+    private final MemberRepository memberRepository;
+    private final ChatRoomRepository chatRoomRepository;
+    private final ChatRoomService chatRoomService;
+
+    @Transactional
+    public MatchRequestResponseDto.MatchRequestCreateResponse createMatchRequest(
+            Long memberId,
+            MatchRequestRequestDto.CreateMatchRequest request
+    ) {
+        // 요청자 조회
+        Member member = getMember(memberId);
+
+        // 요청 팀은 팀장 기준으로 식별
+        Team requestTeam = teamRepository.findByLeader(member)
+                .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_TEAM_LEADER));
+
+        // 매칭 가능한 상태인지 확인
+        validateTeamReady(requestTeam);
+
+        // 대상 팀 조회
+        Team targetTeam = teamRepository.findById(request.targetTeamId())
+                .orElseThrow(() -> new BaseException(BaseResponseStatus.TEAM_NOT_FOUND));
+
+        // 자기 팀으로는 요청 불가
+        if (requestTeam.getId().equals(targetTeam.getId())) {
+            throw new BaseException(BaseResponseStatus.MATCH_REQUEST_SELF);
+        }
+
+        // 성별 매칭 제한
+        if (requestTeam.getGender() == targetTeam.getGender()) {
+            throw new BaseException(BaseResponseStatus.MATCH_REQUEST_SAME_GENDER);
+        }
+
+        // 대상 팀도 매칭 가능한 상태인지 확인
+        validateTeamReady(targetTeam);
+
+        // 기존 요청(대기/수락) 중복 방지
+        if (matchRequestRepository.findByTeamsAndStatus(requestTeam, targetTeam,
+                MatchRequestStatus.PENDING).isPresent()) {
+            throw new BaseException(BaseResponseStatus.MATCH_REQUEST_ALREADY_EXISTS);
+        }
+
+        if (matchRequestRepository.findByTeamsAndStatus(requestTeam, targetTeam,
+                MatchRequestStatus.ACCEPTED).isPresent()) {
+            throw new BaseException(BaseResponseStatus.MATCH_REQUEST_ALREADY_EXISTS);
+        }
+
+        // 이미 채팅방이 존재하면 요청 불가
+        Team maleTeam = requestTeam.getGender() == Gender.MALE ? requestTeam : targetTeam;
+        Team femaleTeam = requestTeam.getGender() == Gender.MALE ? targetTeam : requestTeam;
+
+        if (chatRoomRepository.existsByMaleTeamAndFemaleTeam(maleTeam, femaleTeam)) {
+            throw new BaseException(BaseResponseStatus.CHATROOM_ALREADY_EXISTS);
+        }
+
+        // 매칭 요청 생성
+        MatchRequest matchRequest = MatchRequest.builder()
+                .requestTeam(requestTeam)
+                .targetTeam(targetTeam)
+                .build();
+
+        MatchRequest saved = matchRequestRepository.save(matchRequest);
+
+        return MatchRequestResponseDto.MatchRequestCreateResponse.builder()
+                .matchRequestId(saved.getId())
+                .status(saved.getStatus().name())
+                .requestTeamId(requestTeam.getId())
+                .targetTeamId(targetTeam.getId())
+                .createdAt(saved.getCreatedAt())
+                .build();
+    }
+
+    @Transactional
+    public MatchRequestResponseDto.MatchRequestRespondResponse respondMatchRequest(
+            Long memberId,
+            Long matchRequestId,
+            MatchRequestRequestDto.RespondMatchRequest request
+    ) {
+        // 응답자(대상 팀 리더) 확인
+        Member member = getMember(memberId);
+        Team leaderTeam = teamRepository.findByLeader(member)
+                .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_TEAM_LEADER));
+
+        // 요청 및 연관 팀 로딩
+        MatchRequest matchRequest = matchRequestRepository.findByIdWithTeams(matchRequestId)
+                .orElseThrow(() -> new BaseException(BaseResponseStatus.MATCH_REQUEST_NOT_FOUND));
+
+        // 대상 팀 리더만 응답 가능
+        if (!leaderTeam.getId().equals(matchRequest.getTargetTeam().getId())) {
+            throw new BaseException(BaseResponseStatus.NOT_TEAM_LEADER);
+        }
+
+        // 만료/상태 검증
+        matchRequest.expireIfNeeded();
+        if (!matchRequest.canBeProcessed()) {
+            throw new BaseException(matchRequest.isExpired() ?
+                    BaseResponseStatus.MATCH_REQUEST_EXPIRED :
+                    BaseResponseStatus.MATCH_REQUEST_NOT_PENDING);
+        }
+
+        Long chatRoomId = null;
+        if (Boolean.TRUE.equals(request.accept())) {
+            // 수락 시 채팅방 생성 + 환영 메시지
+            matchRequest.accept();
+            matchRequestRepository.save(matchRequest);
+
+            ChatRoom room = chatRoomService.createRoom(matchRequest);
+            chatRoomService.sendWelcomeMessage(room.getRoomId(), room.getLeader().getId());
+            chatRoomId = room.getRoomId();
+        } else {
+            // 거절 처리
+            matchRequest.reject();
+            matchRequestRepository.save(matchRequest);
+        }
+
+        return MatchRequestResponseDto.MatchRequestRespondResponse.builder()
+                .matchRequestId(matchRequest.getId())
+                .status(matchRequest.getStatus().name())
+                .chatRoomId(chatRoomId)
+                .updatedAt(matchRequest.getUpdatedAt())
+                .build();
+    }
+
+    public MatchRequestResponseDto.MatchRequestDetailResponse getMatchRequest(
+            Long memberId,
+            Long matchRequestId
+    ) {
+        // 요청자 팀(리더) 기준 권한 확인
+        Member member = getMember(memberId);
+        Team leaderTeam = teamRepository.findByLeader(member)
+                .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_TEAM_LEADER));
+
+        // 요청 팀 또는 대상 팀만 조회 가능
+        MatchRequest matchRequest = matchRequestRepository.findByIdAndTeamId(
+                        matchRequestId, leaderTeam.getId())
+                .orElseThrow(() -> new BaseException(BaseResponseStatus.MATCH_REQUEST_NOT_FOUND));
+
+        return MatchRequestResponseDto.MatchRequestDetailResponse.builder()
+                .matchRequestId(matchRequest.getId())
+                .status(matchRequest.getStatus().name())
+                .requestTeam(toTeamSummary(matchRequest.getRequestTeam()))
+                .targetTeam(toTeamSummary(matchRequest.getTargetTeam()))
+                .createdAt(matchRequest.getCreatedAt())
+                .updatedAt(matchRequest.getUpdatedAt())
+                .expired(matchRequest.isExpired())
+                .build();
+    }
+
+    public MatchRequestResponseDto.MatchRequestListResponse getMatchRequests(
+            Long memberId,
+            String type,
+            String status
+    ) {
+        // 팀 리더 기준 목록 조회
+        Member member = getMember(memberId);
+        Team leaderTeam = teamRepository.findByLeader(member)
+                .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_TEAM_LEADER));
+
+        // 상태 파라미터 파싱
+        MatchRequestStatus parsedStatus = parseStatus(status);
+
+        List<MatchRequest> requests;
+        if ("sent".equalsIgnoreCase(type)) {
+            // 보낸 요청 목록
+            requests = parsedStatus == null ?
+                    matchRequestRepository.findByRequestTeamOrderByCreatedAtDesc(leaderTeam) :
+                    matchRequestRepository.findByRequestTeamAndStatusOrderByCreatedAtDesc(
+                            leaderTeam, parsedStatus);
+        } else if ("received".equalsIgnoreCase(type)) {
+            // 받은 요청 목록
+            requests = parsedStatus == null ?
+                    matchRequestRepository.findByTargetTeamOrderByCreatedAtDesc(leaderTeam) :
+                    matchRequestRepository.findByTargetTeamAndStatusOrderByCreatedAtDesc(
+                            leaderTeam, parsedStatus);
+        } else {
+            throw new BaseException(BaseResponseStatus.INVALID_REQUEST);
+        }
+
+        List<MatchRequestResponseDto.MatchRequestSummary> summaries = requests.stream()
+                .map(this::toSummary)
+                .toList();
+
+        return MatchRequestResponseDto.MatchRequestListResponse.builder()
+                .requests(summaries)
+                .totalCount(summaries.size())
+                .build();
+    }
+
+    private MatchRequestResponseDto.MatchRequestSummary toSummary(MatchRequest matchRequest) {
+        return MatchRequestResponseDto.MatchRequestSummary.builder()
+                .matchRequestId(matchRequest.getId())
+                .status(matchRequest.getStatus().name())
+                .requestTeam(toTeamSummary(matchRequest.getRequestTeam()))
+                .targetTeam(toTeamSummary(matchRequest.getTargetTeam()))
+                .createdAt(matchRequest.getCreatedAt())
+                .build();
+    }
+
+    private MatchRequestResponseDto.TeamSummary toTeamSummary(Team team) {
+        // 현재 인원은 TeamMember 기준 카운트
+        int currentMemberCount = (int) teamMemberRepository.countByTeam(team);
+        return MatchRequestResponseDto.TeamSummary.builder()
+                .teamId(team.getId())
+                .title(team.getTitle())
+                .teamSize(team.getTeamSize())
+                .gender(team.getGender())
+                .currentMemberCount(currentMemberCount)
+                .targetMemberCount(team.getTeamSize().getSize())
+                .build();
+    }
+
+    private MatchRequestStatus parseStatus(String status) {
+        // null/blank면 필터 미적용
+        if (status == null || status.isBlank()) {
+            return null;
+        }
+        try {
+            return MatchRequestStatus.valueOf(status.toUpperCase());
+        } catch (IllegalArgumentException ex) {
+            throw new BaseException(BaseResponseStatus.INVALID_REQUEST);
+        }
+    }
+
+    private Member getMember(Long memberId) {
+        // 활성 회원 조회
+        return memberRepository.findById(memberId)
+                .orElseThrow(() -> new BaseException(BaseResponseStatus.MEMBER_NOT_FOUND));
+    }
+
+    private void validateTeamReady(Team team) {
+        // 팀 상태가 매칭 가능해야 함
+        if (!team.canRequestMatch()) {
+            throw new BaseException(BaseResponseStatus.TEAM_NOT_READY);
+        }
+    }
+}

--- a/src/main/java/com/mini/buting/api/matchRequest/service/MatchRequestService.java
+++ b/src/main/java/com/mini/buting/api/matchRequest/service/MatchRequestService.java
@@ -43,14 +43,14 @@ public class MatchRequestService {
         Member member = getMember(memberId);
 
         // 요청 팀은 팀장 기준으로 식별
-        Team requestTeam = teamRepository.findByLeader(member)
+        Team requestTeam = teamRepository.findByLeaderAndIsDeletedFalse(member)
                         .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_TEAM_LEADER));
 
         // 매칭 가능한 상태인지 확인
         validateTeamReady(requestTeam);
 
         // 대상 팀 조회
-        Team targetTeam = teamRepository.findById(request.targetTeamId())
+        Team targetTeam = teamRepository.findByIdAndIsDeletedFalse(request.targetTeamId())
                         .orElseThrow(() -> new BaseException(BaseResponseStatus.TEAM_NOT_FOUND));
 
         // 자기 팀으로는 요청 불가
@@ -103,7 +103,7 @@ public class MatchRequestService {
                     Long matchRequestId, MatchRequestRequestDto.RespondMatchRequest request) {
         // 응답자(대상 팀 리더) 확인
         Member member = getMember(memberId);
-        Team leaderTeam = teamRepository.findByLeader(member)
+        Team leaderTeam = teamRepository.findByLeaderAndIsDeletedFalse(member)
                         .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_TEAM_LEADER));
 
         // 요청 및 연관 팀 로딩
@@ -149,7 +149,7 @@ public class MatchRequestService {
                     Long matchRequestId) {
         // 요청자 팀(리더) 기준 권한 확인
         Member member = getMember(memberId);
-        Team leaderTeam = teamRepository.findByLeader(member)
+        Team leaderTeam = teamRepository.findByLeaderAndIsDeletedFalse(member)
                         .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_TEAM_LEADER));
 
         // 요청 팀 또는 대상 팀만 조회 가능
@@ -172,7 +172,7 @@ public class MatchRequestService {
                     String type, String status) {
         // 팀 리더 기준 목록 조회
         Member member = getMember(memberId);
-        Team leaderTeam = teamRepository.findByLeader(member)
+        Team leaderTeam = teamRepository.findByLeaderAndIsDeletedFalse(member)
                         .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_TEAM_LEADER));
 
         // 상태 파라미터 파싱

--- a/src/main/java/com/mini/buting/api/team/controller/TeamController.java
+++ b/src/main/java/com/mini/buting/api/team/controller/TeamController.java
@@ -2,6 +2,9 @@ package com.mini.buting.api.team.controller;
 
 import com.mini.buting.api.team.dto.request.TeamRequestDto;
 import com.mini.buting.api.team.dto.response.TeamResponseDto;
+import com.mini.buting.api.team.domain.Gender;
+import com.mini.buting.api.team.domain.TeamMood;
+import com.mini.buting.api.team.domain.TeamSize;
 import com.mini.buting.api.team.service.TeamInvitationService;
 import com.mini.buting.api.team.service.TeamService;
 import com.mini.buting.global.response.BaseResponse;
@@ -11,6 +14,8 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -88,5 +93,57 @@ public class TeamController {
                         teamInvitationService.respondToInvitation(memberId, invitationId, request);
 
         return ResponseEntity.ok(BaseResponse.onSuccess(response));
+    }
+
+    @Operation(summary = "팀 매칭글 목록 조회", description = "오픈된 팀(매칭글) 목록을 필터링하여 조회합니다.")
+    @GetMapping("/matching-posts")
+    public ResponseEntity<BaseResponse<Page<TeamResponseDto.TeamMatchPostSummary>>> getMatchingPosts(
+                    @Parameter(description = "사용자 ID")
+                    @RequestHeader(value = "X-User-Id", required = false, defaultValue = "1")
+                    Long memberId,
+                    @Parameter(description = "MALE | FEMALE") @RequestParam(required = false)
+                    Gender gender,
+                    @Parameter(description = "TWO_ON_TWO | THREE_ON_THREE | ...") @RequestParam(required = false)
+                    TeamSize teamSize,
+                    @Parameter(description = "ROMANTIC_TENSION | ...") @RequestParam(required = false)
+                    TeamMood preferredMood,
+                    Pageable pageable) {
+
+        Page<TeamResponseDto.TeamMatchPostSummary> response =
+                        teamService.getMatchingPosts(gender, teamSize, preferredMood, pageable);
+
+        return ResponseEntity.ok(BaseResponse.onSuccess(response));
+    }
+
+    @Operation(summary = "팀 매칭글 상세 조회", description = "오픈된 팀(매칭글) 상세 정보를 조회합니다.")
+    @GetMapping("/matching-posts/{teamId}")
+    public ResponseEntity<BaseResponse<TeamResponseDto.TeamMatchPostDetail>> getMatchingPostDetail(
+                    @Parameter(description = "팀(매칭글) ID", required = true) @PathVariable Long teamId) {
+        TeamResponseDto.TeamMatchPostDetail response = teamService.getMatchingPostDetail(teamId);
+        return ResponseEntity.ok(BaseResponse.onSuccess(response));
+    }
+
+    @Operation(summary = "내가 팀장인 매칭글 수정", description = "팀장만 매칭글을 수정할 수 있습니다. (매칭 성사 전까지만 가능)")
+    @PatchMapping("/matching-posts/{teamId}")
+    public ResponseEntity<BaseResponse<TeamResponseDto.TeamMatchPostDetail>> updateMatchingPost(
+                    @Parameter(description = "팀장 ID", required = true)
+                    @RequestHeader(value = "X-User-Id", required = false, defaultValue = "1")
+                    Long leaderId,
+                    @Parameter(description = "팀(매칭글) ID", required = true) @PathVariable Long teamId,
+                    @Valid @RequestBody TeamRequestDto.UpdateMatchPostRequest request) {
+        TeamResponseDto.TeamMatchPostDetail response =
+                        teamService.updateMatchingPost(leaderId, teamId, request);
+        return ResponseEntity.ok(BaseResponse.onSuccess(response));
+    }
+
+    @Operation(summary = "내가 팀장인 매칭글 삭제", description = "팀장만 매칭글을 삭제(해체)할 수 있습니다. (매칭 성사 전까지만 가능)")
+    @DeleteMapping("/matching-posts/{teamId}")
+    public ResponseEntity<BaseResponse<Void>> deleteMatchingPost(
+                    @Parameter(description = "팀장 ID", required = true)
+                    @RequestHeader(value = "X-User-Id", required = false, defaultValue = "1")
+                    Long leaderId,
+                    @Parameter(description = "팀(매칭글) ID", required = true) @PathVariable Long teamId) {
+        teamService.deleteMatchingPost(leaderId, teamId);
+        return ResponseEntity.ok(BaseResponse.onSuccess());
     }
 }

--- a/src/main/java/com/mini/buting/api/team/domain/Team.java
+++ b/src/main/java/com/mini/buting/api/team/domain/Team.java
@@ -13,6 +13,7 @@ import lombok.NoArgsConstructor;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.time.LocalDateTime;
 
 @Entity
 @Table(name = "Team", indexes = {
@@ -82,6 +83,12 @@ public class Team extends BaseTimeEntity {
     @Column(name = "is_open", nullable = false)
     private Boolean isOpen;
 
+    @Column(name = "is_deleted", nullable = false)
+    private Boolean isDeleted = false;
+
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+
     // 연관관계
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "leader_id", nullable = false)
@@ -120,8 +127,29 @@ public class Team extends BaseTimeEntity {
         this.isOpen = isOpen;
     }
 
+    public void updateTitle(String title) {
+        this.title = title;
+    }
+
     public void updateDescription(String description) {
         this.description = description;
+    }
+
+    public void updatePreferredMood(TeamMood preferredMood) {
+        this.preferredMood = preferredMood;
+    }
+
+    public void updatePreferredAgeRange(Integer preferredAgeMin, Integer preferredAgeMax) {
+        this.preferredAgeMin = preferredAgeMin == null ? null : preferredAgeMin.byteValue();
+        this.preferredAgeMax = preferredAgeMax == null ? null : preferredAgeMax.byteValue();
+    }
+
+    public void updatePreferredEntryYearRange(Integer preferredEntryYearMin,
+                    Integer preferredEntryYearMax) {
+        this.preferredEntryYearMin =
+                        preferredEntryYearMin == null ? null : preferredEntryYearMin.byteValue();
+        this.preferredEntryYearMax =
+                        preferredEntryYearMax == null ? null : preferredEntryYearMax.byteValue();
     }
 
     public void activate() {
@@ -137,7 +165,16 @@ public class Team extends BaseTimeEntity {
     }
 
     public boolean canRequestMatch() {
-        return isFullTeam() && isOpen;
+        return !Boolean.TRUE.equals(isDeleted) && isFullTeam() && Boolean.TRUE.equals(isOpen);
+    }
+
+    public void softDelete() {
+        if (Boolean.TRUE.equals(this.isDeleted)) {
+            throw new BaseException(BaseResponseStatus.INVALID_REQUEST);
+        }
+        this.isDeleted = true;
+        this.deletedAt = LocalDateTime.now();
+        this.isOpen = false;
     }
 
     // 팀원 관리 메서드

--- a/src/main/java/com/mini/buting/api/team/dto/request/TeamRequestDto.java
+++ b/src/main/java/com/mini/buting/api/team/dto/request/TeamRequestDto.java
@@ -75,4 +75,24 @@ public class TeamRequestDto {
     @Builder
     public record RespondToInvitationRequest(@NotNull(message = "응답은 필수입니다.") Boolean accept) {
     }
+
+    /**
+     * 팀 매칭글(=오픈 팀) 수정 요청
+     * - 부분 수정(PATCH) 용도라 모두 optional
+     * - 세부 검증(최소 1개 필드 포함, 범위 쌍 동시 입력, min<=max 등)은 서비스에서 처리
+     */
+    @Builder
+    public record UpdateMatchPostRequest(
+                    @Size(max = 50, message = "팀 제목은 50자를 초과할 수 없습니다.") String title,
+                    @Size(max = 255, message = "팀 소개는 255자를 초과할 수 없습니다.") String description,
+                    TeamMood preferredMood,
+                    @Min(value = 18, message = "최소 나이는 18세 이상이어야 합니다.") @Max(value = 100,
+                                    message = "최소 나이는 100세 이하여야 합니다.") Integer preferredAgeMin,
+                    @Min(value = 18, message = "최대 나이는 18세 이상이어야 합니다.") @Max(value = 100,
+                                    message = "최대 나이는 100세 이하여야 합니다.") Integer preferredAgeMax,
+                    @Min(value = 0, message = "최소 학번은 0 이상이어야 합니다.") @Max(value = 99,
+                                    message = "최소 학번은 99 이하여야 합니다.") Integer preferredEntryYearMin,
+                    @Min(value = 0, message = "최대 학번은 0 이상이어야 합니다.") @Max(value = 99,
+                                    message = "최대 학번은 99 이하여야 합니다.") Integer preferredEntryYearMax) {
+    }
 }

--- a/src/main/java/com/mini/buting/api/team/dto/response/TeamResponseDto.java
+++ b/src/main/java/com/mini/buting/api/team/dto/response/TeamResponseDto.java
@@ -1,5 +1,6 @@
 package com.mini.buting.api.team.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.mini.buting.api.team.domain.*;
 import lombok.Builder;
 
@@ -64,5 +65,34 @@ public class TeamResponseDto {
     public record RespondToInvitationResponse(Long invitationId,
                                               TeamInvitation.InvitationStatus status,
                                               String message) {
+    }
+
+    /**
+     * 팀 매칭글(=오픈 팀) 목록 아이템
+     */
+    @Builder
+    public record TeamMatchPostSummary(Long teamId, String title, TeamSize teamSize, Gender gender,
+                                       String preferredMood,
+                                       Integer preferredAgeMin, Integer preferredAgeMax,
+                                       Integer preferredEntryYearMin, Integer preferredEntryYearMax,
+                                       Integer currentMemberCount, Integer targetMemberCount,
+                                       @JsonFormat(shape = JsonFormat.Shape.STRING,
+                                                       pattern = "yyyy-MM-dd HH:mm:ss") LocalDateTime createdAt) {
+    }
+
+    /**
+     * 팀 매칭글(=오픈 팀) 상세
+     */
+    @Builder
+    public record TeamMatchPostDetail(Long teamId, String title, String description, TeamSize teamSize,
+                                      Gender gender, String preferredMood,
+                                      Integer preferredAgeMin, Integer preferredAgeMax,
+                                      Integer preferredEntryYearMin, Integer preferredEntryYearMax,
+                                      Integer currentMemberCount, Integer targetMemberCount,
+                                      MemberInfo leaderInfo,
+                                      @JsonFormat(shape = JsonFormat.Shape.STRING,
+                                                      pattern = "yyyy-MM-dd HH:mm:ss") LocalDateTime createdAt,
+                                      @JsonFormat(shape = JsonFormat.Shape.STRING,
+                                                      pattern = "yyyy-MM-dd HH:mm:ss") LocalDateTime updatedAt) {
     }
 }

--- a/src/main/java/com/mini/buting/api/team/repository/TeamInvitationRepository.java
+++ b/src/main/java/com/mini/buting/api/team/repository/TeamInvitationRepository.java
@@ -24,7 +24,7 @@ public interface TeamInvitationRepository extends JpaRepository<TeamInvitation, 
     /**
      * 특정 멤버가 받은 대기중인 초대들 조회
      */
-    @Query("SELECT ti FROM TeamInvitation ti " + "JOIN FETCH ti.team t " + "JOIN FETCH ti.inviter " + "WHERE ti.invitee = :invitee " + "AND ti.status = 'PENDING' " + "AND ti.expiredAt > :now")
+    @Query("SELECT ti FROM TeamInvitation ti " + "JOIN FETCH ti.team t " + "JOIN FETCH ti.inviter " + "WHERE ti.invitee = :invitee " + "AND ti.status = 'PENDING' " + "AND ti.expiredAt > :now " + "AND t.isDeleted = false")
     List<TeamInvitation> findPendingInvitationsByInvitee(@Param("invitee") Member invitee,
                     @Param("now") LocalDateTime now);
 
@@ -36,7 +36,7 @@ public interface TeamInvitationRepository extends JpaRepository<TeamInvitation, 
     /**
      * 초대 ID와 초대받은 사람으로 초대 조회 (권한 확인용)
      */
-    @Query("SELECT ti FROM TeamInvitation ti " + "JOIN FETCH ti.team " + "JOIN FETCH ti.inviter " + "WHERE ti.id = :invitationId AND ti.invitee = :invitee")
+    @Query("SELECT ti FROM TeamInvitation ti " + "JOIN FETCH ti.team t " + "JOIN FETCH ti.inviter " + "WHERE ti.id = :invitationId AND ti.invitee = :invitee " + "AND t.isDeleted = false")
     Optional<TeamInvitation> findByIdAndInvitee(@Param("invitationId") Long invitationId,
                     @Param("invitee") Member invitee);
 

--- a/src/main/java/com/mini/buting/api/team/repository/TeamMemberRepository.java
+++ b/src/main/java/com/mini/buting/api/team/repository/TeamMemberRepository.java
@@ -36,4 +36,19 @@ public interface TeamMemberRepository extends JpaRepository<TeamMember, TeamMemb
 
     @Query("SELECT COUNT(tm) FROM TeamMember tm WHERE tm.team = :team")
     long countByTeam(@Param("team") Team team);
+
+    /**
+     * 팀별 멤버 수 집계 (목록 조회 최적화)
+     */
+    @Query("SELECT tm.team.id AS teamId, COUNT(tm) AS memberCount " +
+                    "FROM TeamMember tm " +
+                    "WHERE tm.team.id IN :teamIds " +
+                    "GROUP BY tm.team.id")
+    List<TeamMemberCount> countMembersByTeamIds(@Param("teamIds") List<Long> teamIds);
+
+    interface TeamMemberCount {
+        Long getTeamId();
+
+        Long getMemberCount();
+    }
 }

--- a/src/main/java/com/mini/buting/api/team/repository/TeamRepository.java
+++ b/src/main/java/com/mini/buting/api/team/repository/TeamRepository.java
@@ -3,9 +3,15 @@ package com.mini.buting.api.team.repository;
 import com.mini.buting.api.team.domain.Team;
 import com.mini.buting.api.member.domain.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import com.mini.buting.api.team.domain.Gender;
+import com.mini.buting.api.team.domain.TeamMood;
+import com.mini.buting.api.team.domain.TeamSize;
 
 import java.util.Optional;
 
@@ -15,22 +21,48 @@ public interface TeamRepository extends JpaRepository<Team, Long> {
     /**
      * 특정 멤버가 팀장으로 있는 팀 조회
      */
-    Optional<Team> findByLeader(Member leader);
+    Optional<Team> findByLeaderAndIsDeletedFalse(Member leader);
 
     /**
      * 특정 멤버가 팀장으로 있는 팀 존재 여부 확인
      */
-    boolean existsByLeader(Member leader);
+    boolean existsByLeaderAndIsDeletedFalse(Member leader);
+
+    /**
+     * 팀 단건 조회 (삭제된 팀 제외)
+     */
+    Optional<Team> findByIdAndIsDeletedFalse(Long teamId);
+
+    /**
+     * 오픈된 팀(=매칭글) 단건 조회 (삭제 제외)
+     */
+    Optional<Team> findByIdAndIsOpenTrueAndIsDeletedFalse(Long teamId);
 
     /**
      * 팀과 해당 팀의 멤버들을 함께 조회
      */
-    @Query("SELECT t FROM Team t " + "LEFT JOIN FETCH t.teamMembers tm " + "LEFT JOIN FETCH tm.member " + "WHERE t.id = :teamId")
+    @Query("SELECT t FROM Team t " + "LEFT JOIN FETCH t.teamMembers tm " + "LEFT JOIN FETCH tm.member " + "WHERE t.id = :teamId AND t.isDeleted = false")
     Optional<Team> findByIdWithMembers(@Param("teamId") Long teamId);
 
     /**
      * 팀과 팀장 정보를 함께 조회
      */
-    @Query("SELECT t FROM Team t " + "JOIN FETCH t.leader " + "WHERE t.id = :teamId")
+    @Query("SELECT t FROM Team t " + "JOIN FETCH t.leader " + "WHERE t.id = :teamId AND t.isDeleted = false")
     Optional<Team> findByIdWithLeader(@Param("teamId") Long teamId);
+
+    /**
+     * 매칭글 목록 조회 (오픈 + 삭제 제외 + 옵션 필터)
+     */
+    @Query("""
+                    SELECT t
+                    FROM Team t
+                    WHERE t.isOpen = true
+                      AND t.isDeleted = false
+                      AND (:gender IS NULL OR t.gender = :gender)
+                      AND (:teamSize IS NULL OR t.teamSize = :teamSize)
+                      AND (:preferredMood IS NULL OR t.preferredMood = :preferredMood)
+                    """)
+    Page<Team> findMatchingPosts(@Param("gender") Gender gender,
+                    @Param("teamSize") TeamSize teamSize,
+                    @Param("preferredMood") TeamMood preferredMood, Pageable pageable);
 }

--- a/src/main/java/com/mini/buting/api/team/service/TeamService.java
+++ b/src/main/java/com/mini/buting/api/team/service/TeamService.java
@@ -2,12 +2,15 @@ package com.mini.buting.api.team.service;
 
 import com.mini.buting.api.friend.domain.Friend;
 import com.mini.buting.api.friend.repository.FriendRepository;
+import com.mini.buting.api.matchRequest.repository.MatchRequestRepository;
 import com.mini.buting.api.member.domain.Member;
 import com.mini.buting.api.member.repository.MemberRepository;
 import com.mini.buting.api.team.domain.Gender;
 import com.mini.buting.api.team.domain.Team;
 import com.mini.buting.api.team.domain.TeamInvitation;
 import com.mini.buting.api.team.domain.TeamMember;
+import com.mini.buting.api.team.domain.TeamMood;
+import com.mini.buting.api.team.domain.TeamSize;
 import com.mini.buting.api.team.dto.request.TeamRequestDto;
 import com.mini.buting.api.team.dto.response.TeamResponseDto;
 import com.mini.buting.api.team.repository.TeamInvitationRepository;
@@ -17,10 +20,14 @@ import com.mini.buting.global.exception.BaseException;
 import com.mini.buting.global.response.BaseResponseStatus;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 @Service
@@ -34,6 +41,7 @@ public class TeamService {
     private final MemberRepository memberRepository;
     private final FriendRepository friendRepository;
     private final TeamMemberRepository teamMemberRepository;
+    private final MatchRequestRepository matchRequestRepository;
 
     /**
      * 팀 생성
@@ -49,7 +57,7 @@ public class TeamService {
                         .orElseThrow(() -> new BaseException(BaseResponseStatus.MEMBER_NOT_FOUND));
 
         // 2. 팀장이 이미 다른 팀의 리더인지 확인
-        if (teamRepository.existsByLeader(leader)) {
+        if (teamRepository.existsByLeaderAndIsDeletedFalse(leader)) {
             throw new BaseException(BaseResponseStatus.ALREADY_TEAM_LEADER);
         }
 
@@ -218,6 +226,153 @@ public class TeamService {
 
             log.debug("팀 오픈 상태 변경 - teamId: {}, 모든 초대가 수락됨", team.getId());
         }
+    }
+
+    /**
+     * 팀 매칭글(=오픈 팀) 목록 조회
+     */
+    public Page<TeamResponseDto.TeamMatchPostSummary> getMatchingPosts(Gender gender, TeamSize teamSize,
+                    TeamMood preferredMood, Pageable pageable) {
+        Page<Team> page = teamRepository.findMatchingPosts(gender, teamSize, preferredMood, pageable);
+
+        List<Long> teamIds = page.getContent().stream().map(Team::getId).toList();
+        Map<Long, Long> memberCountMap = new HashMap<>();
+        if (!teamIds.isEmpty()) {
+            teamMemberRepository.countMembersByTeamIds(teamIds).forEach(row -> memberCountMap.put(
+                            row.getTeamId(), row.getMemberCount()));
+        }
+
+        return page.map(team -> {
+            long current = memberCountMap.getOrDefault(team.getId(), 0L);
+            return TeamResponseDto.TeamMatchPostSummary.builder().teamId(team.getId())
+                            .title(team.getTitle()).teamSize(team.getTeamSize())
+                            .gender(team.getGender())
+                            .preferredMood(team.getPreferredMood().getDisplayName())
+                            .preferredAgeMin(team.getPreferredAgeMin().intValue())
+                            .preferredAgeMax(team.getPreferredAgeMax().intValue())
+                            .preferredEntryYearMin(team.getPreferredEntryYearMin().intValue())
+                            .preferredEntryYearMax(team.getPreferredEntryYearMax().intValue())
+                            .currentMemberCount((int) current)
+                            .targetMemberCount(team.getTeamSize().getSize())
+                            .createdAt(team.getCreatedAt()).build();
+        });
+    }
+
+    /**
+     * 팀 매칭글(=오픈 팀) 상세 조회
+     */
+    public TeamResponseDto.TeamMatchPostDetail getMatchingPostDetail(Long teamId) {
+        Team team = teamRepository.findByIdAndIsOpenTrueAndIsDeletedFalse(teamId)
+                        .orElseThrow(() -> new BaseException(BaseResponseStatus.TEAM_NOT_FOUND));
+        return toMatchPostDetail(team);
+    }
+
+    /**
+     * 팀장 전용: 매칭글 수정 (매칭 성사 전까지만 허용)
+     */
+    @Transactional
+    public TeamResponseDto.TeamMatchPostDetail updateMatchingPost(Long leaderId, Long teamId,
+                    TeamRequestDto.UpdateMatchPostRequest request) {
+        Team team = teamRepository.findByIdWithLeader(teamId)
+                        .orElseThrow(() -> new BaseException(BaseResponseStatus.TEAM_NOT_FOUND));
+
+        if (!team.getLeader().getId().equals(leaderId)) {
+            throw new BaseException(BaseResponseStatus.NOT_TEAM_LEADER);
+        }
+
+        // 매칭 성사 후에는 수정 불가
+        if (matchRequestRepository.existsAcceptedByTeamId(teamId)) {
+            throw new BaseException(BaseResponseStatus.TEAM_ALREADY_MATCHED);
+        }
+
+        boolean hasAny = request.title() != null || request.description() != null
+                        || request.preferredMood() != null || request.preferredAgeMin() != null
+                        || request.preferredAgeMax() != null || request.preferredEntryYearMin() != null
+                        || request.preferredEntryYearMax() != null;
+        if (!hasAny) {
+            throw new BaseException(BaseResponseStatus.INVALID_REQUEST);
+        }
+
+        // 범위 쌍 검증
+        if ((request.preferredAgeMin() == null) != (request.preferredAgeMax() == null)) {
+            throw new BaseException(BaseResponseStatus.INVALID_REQUEST);
+        }
+        if (request.preferredAgeMin() != null && request.preferredAgeMin() > request.preferredAgeMax()) {
+            throw new BaseException(BaseResponseStatus.INVALID_REQUEST);
+        }
+        if ((request.preferredEntryYearMin() == null) != (request.preferredEntryYearMax() == null)) {
+            throw new BaseException(BaseResponseStatus.INVALID_REQUEST);
+        }
+        if (request.preferredEntryYearMin() != null
+                        && request.preferredEntryYearMin() > request.preferredEntryYearMax()) {
+            throw new BaseException(BaseResponseStatus.INVALID_REQUEST);
+        }
+
+        if (request.title() != null) {
+            team.updateTitle(request.title());
+        }
+        if (request.description() != null) {
+            team.updateDescription(request.description());
+        }
+        if (request.preferredMood() != null) {
+            team.updatePreferredMood(request.preferredMood());
+        }
+        if (request.preferredAgeMin() != null) {
+            team.updatePreferredAgeRange(request.preferredAgeMin(), request.preferredAgeMax());
+        }
+        if (request.preferredEntryYearMin() != null) {
+            team.updatePreferredEntryYearRange(request.preferredEntryYearMin(),
+                            request.preferredEntryYearMax());
+        }
+
+        teamRepository.save(team);
+        return toMatchPostDetail(team);
+    }
+
+    /**
+     * 팀장 전용: 매칭글 삭제(해체) - 매칭 성사 전까지만 허용
+     */
+    @Transactional
+    public void deleteMatchingPost(Long leaderId, Long teamId) {
+        Team team = teamRepository.findByIdWithLeader(teamId)
+                        .orElseThrow(() -> new BaseException(BaseResponseStatus.TEAM_NOT_FOUND));
+
+        if (!team.getLeader().getId().equals(leaderId)) {
+            throw new BaseException(BaseResponseStatus.NOT_TEAM_LEADER);
+        }
+
+        if (matchRequestRepository.existsAcceptedByTeamId(teamId)) {
+            throw new BaseException(BaseResponseStatus.TEAM_ALREADY_MATCHED);
+        }
+
+        team.softDelete();
+        teamRepository.save(team);
+    }
+
+    private TeamResponseDto.TeamMatchPostDetail toMatchPostDetail(Team team) {
+        long currentMemberCount = teamMemberRepository.countByTeam(team);
+
+        Member leader = team.getLeader();
+        TeamResponseDto.MemberInfo leaderInfo = TeamResponseDto.MemberInfo.builder()
+                        .memberId(leader.getId()).nickname(leader.getNickname()).age(leader.getAge())
+                        .bio(leader.getBio())
+                        .universityName(leader.getUniversity() != null ?
+                                        leader.getUniversity().getName() :
+                                        null)
+                        .collegeName(leader.getCollege() != null ? leader.getCollege().getName() : null)
+                        .build();
+
+        return TeamResponseDto.TeamMatchPostDetail.builder().teamId(team.getId())
+                        .title(team.getTitle()).description(team.getDescription())
+                        .teamSize(team.getTeamSize()).gender(team.getGender())
+                        .preferredMood(team.getPreferredMood().getDisplayName())
+                        .preferredAgeMin(team.getPreferredAgeMin().intValue())
+                        .preferredAgeMax(team.getPreferredAgeMax().intValue())
+                        .preferredEntryYearMin(team.getPreferredEntryYearMin().intValue())
+                        .preferredEntryYearMax(team.getPreferredEntryYearMax().intValue())
+                        .currentMemberCount((int) currentMemberCount)
+                        .targetMemberCount(team.getTeamSize().getSize()).leaderInfo(leaderInfo)
+                        .createdAt(team.getCreatedAt()).updatedAt(team.getUpdatedAt()).build();
     }
 
     /**

--- a/src/main/java/com/mini/buting/global/response/BaseResponseStatus.java
+++ b/src/main/java/com/mini/buting/global/response/BaseResponseStatus.java
@@ -76,7 +76,11 @@ public enum BaseResponseStatus {
      */
     MATCH_REQUEST_NOT_PENDING(HttpStatus.BAD_REQUEST, false, 4001, "대기 중인 매칭 요청이 아닙니다."),
     MATCH_REQUEST_EXPIRED(HttpStatus.BAD_REQUEST, false, 4002, "만료된 매칭 요청입니다."),
-    MATCH_REQUEST_NOT_ACCEPTED(HttpStatus.BAD_REQUEST, false, 4001, "수락 된 매칭 요청이 아닙니다."),
+    MATCH_REQUEST_NOT_ACCEPTED(HttpStatus.BAD_REQUEST, false, 4003, "수락 된 매칭 요청이 아닙니다."),
+    MATCH_REQUEST_NOT_FOUND(HttpStatus.NOT_FOUND, false, 4004, "매칭 요청을 찾을 수 없습니다."),
+    MATCH_REQUEST_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, false, 4005, "이미 존재하는 매칭 요청입니다."),
+    MATCH_REQUEST_SELF(HttpStatus.BAD_REQUEST, false, 4006, "같은 팀으로는 매칭 요청을 보낼 수 없습니다."),
+    MATCH_REQUEST_SAME_GENDER(HttpStatus.BAD_REQUEST, false, 4007, "같은 성별 팀과는 매칭할 수 없습니다."),
     /**
      * 4100: MBTI 관련 에러
      */

--- a/src/main/java/com/mini/buting/global/response/BaseResponseStatus.java
+++ b/src/main/java/com/mini/buting/global/response/BaseResponseStatus.java
@@ -120,6 +120,7 @@ public enum BaseResponseStatus {
     TEAM_SIZE_MISMATCH(HttpStatus.BAD_REQUEST, false, 4503, "초대할 멤버 수가 팀 크기와 일치하지 않습니다."),
     DIFFERENT_GENDER_CANNOT_INVITE(HttpStatus.BAD_REQUEST, false, 4504, "다른 성별의 사용자는 초대할 수 없습니다."),
     TEAM_NOT_READY(HttpStatus.BAD_REQUEST, false, 4505, "모든 멤버가 수락해야 팀이 활성화됩니다."),
+    TEAM_ALREADY_MATCHED(HttpStatus.BAD_REQUEST, false, 4506, "매칭이 성사된 팀은 수정/삭제할 수 없습니다."),
 
     /**
      * 5000: 채팅방 관련 에러


### PR DESCRIPTION
<!--
🔀 Develop PR (제목을 입력해주세요)
🚑️ Hotfix MR (제목을 입력해주세요)

📌 사용 예시:
[🔀 FE]
[🔀 BE]
[🚑️ BE]
[🚑️ FE]

⚠️ (괄호) 항목은 모두 지우고 알맞게 작성해주세요.
-->

### 🔗 Connected Issue

Closes #43 

### 📅 Development Period

2026.02.01 ~ 2026.02.03

(ex. YYYY.MM.DD ~ YYYY.MM.DD)

### 📢 Description

- Team 엔티티를 “팀 매칭글”로 보고, 오픈된 팀(=매칭글) 조회/관리 API를 추가했습니다.
추가 API
- GET `/v1/teams/matching-posts` : 매칭글 목록 조회 (필터: gender, teamSize, preferredMood + Pageable)
- GET `/v1/teams/matching-posts/{teamId}` : 매칭글 상세 조회 (오픈된 팀만 노출)
- PATCH `/v1/teams/matching-posts/{teamId}` : 팀장 전용 매칭글 수정 (매칭 성사 전까지만)
- DELETE `/v1/teams/matching-posts/{teamId}` : 팀장 전용 매칭글 삭제(해체) (매칭 성사 전까지만)
- 팀 삭제는 물리 삭제가 아닌 소프트 삭제(isDeleted/deletedAt) 로 처리하여, 삭제된 팀은 목록/상세/초대/매칭요청 등 관련 데이터 접근이 불가능하도록 일관성 있게 적용했습니다.
- 매칭 성사 기준은 MatchRequest가 ACCEPTED인 경우이며, 성사 이후에는 수정/삭제를 TEAM_ALREADY_MATCHED로 차단합니다.

### ✔️ PR Checklist

MR이 아래 사항을 충족하는지 확인해주세요:

- [x] Merge 방향 및 Branch 확인했습니다.
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 코드가 정상적으로 동작하는지 테스트했습니다.
- [x] 해당하는 이슈번호를 올바르게 입력했습니다.

### 🔖 Note

<!-- 참고사항을 적어주세요 -->
- 공통 응답 규격은 BaseResponse를 따릅니다.
- 로컬 서버(8080)에서 API 실호출로 아래를 확인했습니다:
- 목록/필터/상세 정상 응답
- 팀장 권한 검증(NOT_TEAM_LEADER)
- 매칭 성사 후 수정/삭제 차단(TEAM_ALREADY_MATCHED)
- 초대 수락 후 오픈 → 수정 성공 → 삭제 성공 → 삭제 후 상세 조회 차단 확인

#### 이전 이슈를 먼저 받아주세요