### PR TITLE
[🔀 BE] /v1/members/profile/me JWT principal 기반 전환

### DIFF
--- a/src/main/java/com/mini/buting/api/member/controller/AccountController.java
+++ b/src/main/java/com/mini/buting/api/member/controller/AccountController.java
@@ -1,5 +1,7 @@
 package com.mini.buting.api.member.controller;
 
+import com.mini.buting.api.member.dto.MemberProfileResponse;
+import com.mini.buting.api.member.service.MemberService;
 import com.mini.buting.global.response.BaseResponse;
 import com.mini.buting.global.security.principal.AuthUser;
 import com.mini.buting.global.security.util.AuthValidator;
@@ -8,17 +10,32 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Slf4j
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/v1/members/me")
 @Tag(name = "Member - Account", description = "사용자 계정/마이페이지 관련 API")
 public class AccountController {
-    // TODO: 기존 마이페이지 API 이쪽으로 다 옮기기
+
+    private final MemberService memberService;
+
+    @GetMapping()
+    public BaseResponse<MemberProfileResponse> getMyProfile(@AuthenticationPrincipal AuthUser authUser) {
+        long memberId = AuthValidator.require(authUser).getId();
+        log.debug("내 프로필 조회 요청: userId={}", memberId);
+
+        MemberProfileResponse profile = memberService.getMemberProfile(memberId);
+        log.debug("내 프로필 조회 성공: userId={}, nickname={}", memberId, profile.getNickname());
+
+        return BaseResponse.onSuccess(profile);
+    }
 
     @Operation(summary = "회원탈퇴 API", description = "기존 사용자를 비활성화")
     @DeleteMapping()

--- a/src/main/java/com/mini/buting/api/member/controller/MemberController.java
+++ b/src/main/java/com/mini/buting/api/member/controller/MemberController.java
@@ -35,32 +35,16 @@ public class MemberController {
     private final SignUpService signUpService;
 
     /**
-     * 내 프로필 조회
-     * TODO: Spring Security 적용 시 Authentication에서 사용자 정보 추출
-     */
-    @GetMapping("/profile/me")
-    public BaseResponse<MemberProfileResponse> getMyProfile(
-            @RequestHeader(value = "X-User-Id", required = false, defaultValue = "1") Long userId) {
-
-        log.debug("내 프로필 조회 요청: userId={}", userId);
-
-        MemberProfileResponse profile = memberService.getMemberProfile(userId);
-
-        log.debug("내 프로필 조회 성공: userId={}, nickname={}", userId, profile.getNickname());
-        return BaseResponse.onSuccess(profile);
-    }
-
-    /**
      * 특정 회원 프로필 조회
      */
-    @GetMapping("/profile/{userId}")
-    public BaseResponse<MemberProfileResponse> getMemberProfile(@PathVariable Long userId) {
+    @GetMapping("/profile/{memberId}")
+    public BaseResponse<MemberProfileResponse> getMemberProfile(@PathVariable Long memberId) {
 
-        log.debug("회원 프로필 조회 요청: userId={}", userId);
+        log.debug("회원 프로필 조회 요청: userId={}", memberId);
 
-        MemberProfileResponse profile = memberService.getMemberProfile(userId);
+        MemberProfileResponse profile = memberService.getMemberProfile(memberId);
 
-        log.debug("회원 프로필 조회 성공: userId={}, nickname={}", userId, profile.getNickname());
+        log.debug("회원 프로필 조회 성공: userId={}, nickname={}", memberId, profile.getNickname());
         return BaseResponse.onSuccess(profile);
     }
 


### PR DESCRIPTION
### 📅 Development Period

2026.02.21 ~ 2026.02.21

### 📢 Description

- `GET /v1/members/profile/me`에서 사용자 식별 헤더(`X-User-Id`)를 제거하고
- `@AuthenticationPrincipal AuthUser` 기반으로 현재 로그인 사용자 식별 방식으로 전환함
- 인증 사용자 검증에 `AuthValidator`로 인증 누락 시 방어 로직 적용

#### ✅ 변경 범위
- `GET /v1/members/profile/me` 전환

### ✔️ PR Checklist

MR이 아래 사항을 충족하는지 확인해주세요:

- [x] Merge 방향 및 Branch 확인했습니다.
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 코드가 정상적으로 동작하는지 테스트했습니다.

### 🔖 Note
## 반드시 PR #49 (foundation) merge 후 위 PR을 타겟을 `develop`으로 변경하셔서 merge 해주세요.