### PR TITLE
[🔀 BE] Team/Friend/MatchRequest 컨트롤러 JWT Principal 기반 전환

### DIFF
--- a/src/main/java/com/mini/buting/api/friend/controller/FriendController.java
+++ b/src/main/java/com/mini/buting/api/friend/controller/FriendController.java
@@ -1,11 +1,12 @@
 package com.mini.buting.api.friend.controller;
 
 import com.mini.buting.api.friend.dto.request.FriendRequestCreateDto;
-import com.mini.buting.api.friend.dto.request.FriendRequestDto;
 import com.mini.buting.api.friend.dto.response.FriendListResponseDto;
 import com.mini.buting.api.friend.dto.response.FriendRequestResponseDto;
 import com.mini.buting.api.friend.service.FriendService;
 import com.mini.buting.global.response.BaseResponse;
+import com.mini.buting.global.security.principal.AuthUser;
+import com.mini.buting.global.security.util.AuthValidator;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -15,6 +16,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "Friend API", description = "친구 시스템 API")
@@ -29,26 +31,23 @@ public class FriendController {
     @Operation(summary = "친구 요청 보내기", description = "닉네임으로 다른 사용자에게 친구 요청을 보냅니다.")
     @PostMapping("/requests")
     public ResponseEntity<BaseResponse<Void>> sendFriendRequest(
-                    @RequestHeader(value = "X-User-Id", required = false, defaultValue = "1")
-                    Long userId, @Valid @RequestBody FriendRequestCreateDto request) {
-
-        log.debug("친구 요청 API 호출 - 요청자: {}, 대상: {}", userId, request.targetNickname());
-
-        friendService.sendFriendRequest(userId, request);
-
+            @AuthenticationPrincipal AuthUser authUser,
+            @Valid @RequestBody FriendRequestCreateDto request) {
+        long memberId = AuthValidator.require(authUser).getId();
+        log.debug("친구 요청 API 호출 - 요청자: {}, 대상: {}", memberId, request.targetNickname());
+        friendService.sendFriendRequest(memberId, request);
         return ResponseEntity.ok(BaseResponse.onSuccess());
     }
 
     @Operation(summary = "친구 요청 수락하기", description = "받은 친구 요청을 수락합니다.")
     @PostMapping("/requests/{friendRequestId}/accept")
     public ResponseEntity<BaseResponse<Void>> acceptFriendRequest(
-                    @RequestHeader(value = "X-User-Id", required = false, defaultValue = "1")
-                    Long userId,
-                    @Parameter(description = "친구 요청 ID") @PathVariable Long friendRequestId) {
+            @AuthenticationPrincipal AuthUser authUser,
+            @Parameter(description = "친구 요청 ID") @PathVariable Long friendRequestId) {
+        long memberId = AuthValidator.require(authUser).getId();
+        log.debug("친구 요청 수락 API 호출 - 응답자: {}, 요청ID: {}", memberId, friendRequestId);
 
-        log.debug("친구 요청 수락 API 호출 - 응답자: {}, 요청ID: {}", userId, friendRequestId);
-
-        friendService.acceptFriendRequest(userId, friendRequestId);
+        friendService.acceptFriendRequest(memberId, friendRequestId);
 
         return ResponseEntity.ok(BaseResponse.onSuccess());
     }
@@ -56,13 +55,12 @@ public class FriendController {
     @Operation(summary = "친구 요청 거절하기", description = "받은 친구 요청을 거절합니다.")
     @PostMapping("/requests/{friendRequestId}/reject")
     public ResponseEntity<BaseResponse<Void>> rejectFriendRequest(
-                    @RequestHeader(value = "X-User-Id", required = false, defaultValue = "1")
-                    Long userId,
-                    @Parameter(description = "친구 요청 ID") @PathVariable Long friendRequestId) {
+            @AuthenticationPrincipal AuthUser authUser,
+            @Parameter(description = "친구 요청 ID") @PathVariable Long friendRequestId) {
+        long memberId = AuthValidator.require(authUser).getId();
+        log.debug("친구 요청 거절 API 호출 - 응답자: {}, 요청ID: {}", memberId, friendRequestId);
 
-        log.debug("친구 요청 거절 API 호출 - 응답자: {}, 요청ID: {}", userId, friendRequestId);
-
-        friendService.rejectFriendRequest(userId, friendRequestId);
+        friendService.rejectFriendRequest(memberId, friendRequestId);
 
         return ResponseEntity.ok(BaseResponse.onSuccess());
     }
@@ -70,13 +68,12 @@ public class FriendController {
     @Operation(summary = "친구 요청 목록 조회", description = "내가 받은 친구 요청 목록을 조회합니다.")
     @GetMapping("/requests")
     public ResponseEntity<BaseResponse<Page<FriendRequestResponseDto>>> getFriendRequests(
-                    @RequestHeader(value = "X-User-Id", required = false, defaultValue = "1")
-                    Long userId, Pageable pageable) {
+            @AuthenticationPrincipal AuthUser authUser,
+            Pageable pageable) {
+        long memberId = AuthValidator.require(authUser).getId();
+        log.debug("친구 요청 목록 조회 API 호출 - 회원: {}", memberId);
 
-        log.debug("친구 요청 목록 조회 API 호출 - 회원: {}", userId);
-
-        Page<FriendRequestResponseDto>
-                        result = friendService.getReceivedFriendRequests(userId, pageable);
+        Page<FriendRequestResponseDto> result = friendService.getReceivedFriendRequests(memberId, pageable);
 
         return ResponseEntity.ok(BaseResponse.onSuccess(result));
     }
@@ -84,12 +81,12 @@ public class FriendController {
     @Operation(summary = "내 친구 목록 조회", description = "내 친구 목록을 조회합니다.")
     @GetMapping
     public ResponseEntity<BaseResponse<Page<FriendListResponseDto>>> getFriendList(
-                    @RequestHeader(value = "X-User-Id", required = false, defaultValue = "1")
-                    Long userId, Pageable pageable) {
+            @AuthenticationPrincipal AuthUser authUser,
+            Pageable pageable) {
+        long memberId = AuthValidator.require(authUser).getId();
+        log.debug("내 친구 목록 조회 API 호출 - 회원: {}", memberId);
 
-        log.debug("내 친구 목록 조회 API 호출 - 회원: {}", userId);
-
-        Page<FriendListResponseDto> result = friendService.getFriendList(userId, pageable);
+        Page<FriendListResponseDto> result = friendService.getFriendList(memberId, pageable);
 
         return ResponseEntity.ok(BaseResponse.onSuccess(result));
     }

--- a/src/main/java/com/mini/buting/api/matchRequest/controller/MatchRequestController.java
+++ b/src/main/java/com/mini/buting/api/matchRequest/controller/MatchRequestController.java
@@ -4,6 +4,8 @@ import com.mini.buting.api.matchRequest.dto.request.MatchRequestRequestDto;
 import com.mini.buting.api.matchRequest.dto.response.MatchRequestResponseDto;
 import com.mini.buting.api.matchRequest.service.MatchRequestService;
 import com.mini.buting.global.response.BaseResponse;
+import com.mini.buting.global.security.principal.AuthUser;
+import com.mini.buting.global.security.util.AuthValidator;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -12,6 +14,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "MatchRequest", description = "팀 매칭 요청 API")
@@ -26,56 +29,52 @@ public class MatchRequestController {
     @Operation(summary = "매칭 요청 생성", description = "대상 팀에게 매칭 요청을 보냅니다.")
     @PostMapping
     public ResponseEntity<BaseResponse<MatchRequestResponseDto.MatchRequestCreateResponse>> createMatchRequest(
-                    @Parameter(description = "사용자 ID", required = true)
-                    @RequestHeader(value = "X-User-Id", required = false, defaultValue = "1")
-                    Long memberId,
-                    @Valid @RequestBody MatchRequestRequestDto.CreateMatchRequest request) {
+            @AuthenticationPrincipal AuthUser authUser,
+            @Valid @RequestBody MatchRequestRequestDto.CreateMatchRequest request) {
+        long memberId = AuthValidator.require(authUser).getId();
         log.debug("매칭 요청 생성 - memberId: {}, targetTeamId: {}", memberId, request.targetTeamId());
         MatchRequestResponseDto.MatchRequestCreateResponse response =
-                        matchRequestService.createMatchRequest(memberId, request);
+                matchRequestService.createMatchRequest(memberId, request);
         return ResponseEntity.status(HttpStatus.CREATED).body(BaseResponse.onSuccess(response));
     }
 
     @Operation(summary = "매칭 요청 응답", description = "매칭 요청을 수락하거나 거절합니다.")
     @PatchMapping("/{matchRequestId}/respond")
     public ResponseEntity<BaseResponse<MatchRequestResponseDto.MatchRequestRespondResponse>> respondMatchRequest(
-                    @Parameter(description = "사용자 ID", required = true)
-                    @RequestHeader(value = "X-User-Id", required = false, defaultValue = "1")
-                    Long memberId,
-                    @Parameter(description = "매칭 요청 ID", required = true) @PathVariable
-                    Long matchRequestId,
-                    @Valid @RequestBody MatchRequestRequestDto.RespondMatchRequest request) {
+            @AuthenticationPrincipal AuthUser authUser,
+            @Parameter(description = "매칭 요청 ID", required = true) @PathVariable
+            Long matchRequestId,
+            @Valid @RequestBody MatchRequestRequestDto.RespondMatchRequest request) {
+        long memberId = AuthValidator.require(authUser).getId();
         log.debug("매칭 요청 응답 - memberId: {}, matchRequestId: {}, accept: {}", memberId,
-                        matchRequestId, request.accept());
+                matchRequestId, request.accept());
         MatchRequestResponseDto.MatchRequestRespondResponse response =
-                        matchRequestService.respondMatchRequest(memberId, matchRequestId, request);
+                matchRequestService.respondMatchRequest(memberId, matchRequestId, request);
         return ResponseEntity.ok(BaseResponse.onSuccess(response));
     }
 
     @Operation(summary = "매칭 요청 단건 조회", description = "매칭 요청 상세 정보를 조회합니다.")
     @GetMapping("/{matchRequestId}")
     public ResponseEntity<BaseResponse<MatchRequestResponseDto.MatchRequestDetailResponse>> getMatchRequest(
-                    @Parameter(description = "사용자 ID", required = true)
-                    @RequestHeader(value = "X-User-Id", required = false, defaultValue = "1")
-                    Long memberId,
-                    @Parameter(description = "매칭 요청 ID", required = true) @PathVariable
-                    Long matchRequestId) {
+            @AuthenticationPrincipal AuthUser authUser,
+            @Parameter(description = "매칭 요청 ID", required = true) @PathVariable
+            Long matchRequestId) {
+        long memberId = AuthValidator.require(authUser).getId();
         MatchRequestResponseDto.MatchRequestDetailResponse response =
-                        matchRequestService.getMatchRequest(memberId, matchRequestId);
+                matchRequestService.getMatchRequest(memberId, matchRequestId);
         return ResponseEntity.ok(BaseResponse.onSuccess(response));
     }
 
     @Operation(summary = "매칭 요청 목록 조회", description = "보낸/받은 매칭 요청 목록을 조회합니다.")
     @GetMapping
     public ResponseEntity<BaseResponse<MatchRequestResponseDto.MatchRequestListResponse>> getMatchRequests(
-                    @Parameter(description = "사용자 ID", required = true)
-                    @RequestHeader(value = "X-User-Id", required = false, defaultValue = "1")
-                    Long memberId,
-                    @Parameter(description = "sent | received", required = true) @RequestParam
-                    String type, @Parameter(description = "PENDING | ACCEPTED | REJECTED")
-                    @RequestParam(required = false) String status) {
+            @AuthenticationPrincipal AuthUser authUser,
+            @Parameter(description = "sent | received", required = true) @RequestParam
+            String type, @Parameter(description = "PENDING | ACCEPTED | REJECTED")
+            @RequestParam(required = false) String status) {
+        long memberId = AuthValidator.require(authUser).getId();
         MatchRequestResponseDto.MatchRequestListResponse response =
-                        matchRequestService.getMatchRequests(memberId, type, status);
+                matchRequestService.getMatchRequests(memberId, type, status);
         return ResponseEntity.ok(BaseResponse.onSuccess(response));
     }
 }

--- a/src/main/java/com/mini/buting/api/team/controller/TeamController.java
+++ b/src/main/java/com/mini/buting/api/team/controller/TeamController.java
@@ -1,13 +1,15 @@
 package com.mini.buting.api.team.controller;
 
-import com.mini.buting.api.team.dto.request.TeamRequestDto;
-import com.mini.buting.api.team.dto.response.TeamResponseDto;
 import com.mini.buting.api.team.domain.Gender;
 import com.mini.buting.api.team.domain.TeamMood;
 import com.mini.buting.api.team.domain.TeamSize;
+import com.mini.buting.api.team.dto.request.TeamRequestDto;
+import com.mini.buting.api.team.dto.response.TeamResponseDto;
 import com.mini.buting.api.team.service.TeamInvitationService;
 import com.mini.buting.api.team.service.TeamService;
 import com.mini.buting.global.response.BaseResponse;
+import com.mini.buting.global.security.principal.AuthUser;
+import com.mini.buting.global.security.util.AuthValidator;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -18,14 +20,15 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
-@RestController
-@RequestMapping("/v1/teams")
-@RequiredArgsConstructor
 @Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/v1/teams")
 @Tag(name = "Team", description = "팀 관련 API")
 public class TeamController {
 
@@ -35,9 +38,9 @@ public class TeamController {
     @Operation(summary = "팀 생성", description = "새로운 팀을 생성하고 멤버들을 초대합니다.")
     @PostMapping
     public ResponseEntity<BaseResponse<TeamResponseDto.CreateTeamResponse>> createTeam(
-                    @Parameter(description = "팀장 ID", required = true) @RequestHeader("X-User-Id")
-                    Long leaderId, @Valid @RequestBody TeamRequestDto.CreateTeamRequest request) {
-
+            @AuthenticationPrincipal AuthUser authUser,
+            @Valid @RequestBody TeamRequestDto.CreateTeamRequest request) {
+        long leaderId = AuthValidator.require(authUser).getId();
         log.info("팀 생성 API 호출 - leaderId: {}", leaderId);
 
         TeamResponseDto.CreateTeamResponse response = teamService.createTeam(leaderId, request);
@@ -48,49 +51,42 @@ public class TeamController {
     @Operation(summary = "친구 검색", description = "팀 초대를 위해 친구를 검색합니다.")
     @GetMapping("/friends/search")
     public ResponseEntity<BaseResponse<TeamResponseDto.SearchFriendsResponse>> searchFriends(
-                    @Parameter(description = "사용자 ID", required = true) @RequestHeader("X-User-Id")
-                    Long memberId,
-                    @Parameter(description = "검색 키워드 (닉네임 또는 이메일)") @RequestParam(required = false)
-                    String keyword) {
-
+            @AuthenticationPrincipal AuthUser authUser,
+            @Parameter(description = "검색 키워드 (닉네임 또는 이메일)") @RequestParam(required = false)
+            String keyword) {
+        long memberId = AuthValidator.require(authUser).getId();
         log.info("친구 검색 API 호출 - memberId: {}, keyword: {}", memberId, keyword);
 
         TeamRequestDto.SearchFriendsRequest request =
-                        TeamRequestDto.SearchFriendsRequest.builder().keyword(keyword).build();
+                TeamRequestDto.SearchFriendsRequest.builder().keyword(keyword).build();
 
         TeamResponseDto.SearchFriendsResponse response =
-                        teamService.searchFriends(memberId, request);
+                teamService.searchFriends(memberId, request);
 
         return ResponseEntity.ok(BaseResponse.onSuccess(response));
     }
 
     @Operation(summary = "받은 초대 목록", description = "사용자가 받은 팀 초대 목록을 조회합니다.")
     @GetMapping("/invitations/received")
-    public ResponseEntity<BaseResponse<List<TeamResponseDto.TeamInvitationDetailResponse>>> getReceivedInvitations(
-                    @Parameter(description = "사용자 ID", required = true) @RequestHeader("X-User-Id")
-                    Long memberId) {
-
+    public ResponseEntity<BaseResponse<List<TeamResponseDto.TeamInvitationDetailResponse>>> getReceivedInvitations(@AuthenticationPrincipal AuthUser authUser) {
+        long memberId = AuthValidator.require(authUser).getId();
         log.info("받은 초대 목록 API 호출 - memberId: {}", memberId);
-
-        List<TeamResponseDto.TeamInvitationDetailResponse> response =
-                        teamInvitationService.getReceivedInvitations(memberId);
-
-        return ResponseEntity.ok(BaseResponse.onSuccess(response));
+        return ResponseEntity.ok(BaseResponse.onSuccess(teamInvitationService.getReceivedInvitations(memberId)));
     }
 
     @Operation(summary = "초대 응답", description = "팀 초대를 수락하거나 거절합니다.")
     @PatchMapping("/invitations/{invitationId}/respond")
     public ResponseEntity<BaseResponse<TeamResponseDto.RespondToInvitationResponse>> respondToInvitation(
-                    @Parameter(description = "사용자 ID", required = true) @RequestHeader("X-User-Id")
-                    Long memberId, @Parameter(description = "초대 ID", required = true) @PathVariable
-                    Long invitationId,
-                    @Valid @RequestBody TeamRequestDto.RespondToInvitationRequest request) {
-
+            @AuthenticationPrincipal AuthUser authUser,
+            @Parameter(description = "초대 ID", required = true) @PathVariable
+            Long invitationId,
+            @Valid @RequestBody TeamRequestDto.RespondToInvitationRequest request) {
+        long memberId = AuthValidator.require(authUser).getId();
         log.info("초대 응답 API 호출 - memberId: {}, invitationId: {}, accept: {}", memberId,
-                        invitationId, request.accept());
+                invitationId, request.accept());
 
         TeamResponseDto.RespondToInvitationResponse response =
-                        teamInvitationService.respondToInvitation(memberId, invitationId, request);
+                teamInvitationService.respondToInvitation(memberId, invitationId, request);
 
         return ResponseEntity.ok(BaseResponse.onSuccess(response));
     }
@@ -98,19 +94,16 @@ public class TeamController {
     @Operation(summary = "팀 매칭글 목록 조회", description = "오픈된 팀(매칭글) 목록을 필터링하여 조회합니다.")
     @GetMapping("/matching-posts")
     public ResponseEntity<BaseResponse<Page<TeamResponseDto.TeamMatchPostSummary>>> getMatchingPosts(
-                    @Parameter(description = "사용자 ID")
-                    @RequestHeader(value = "X-User-Id", required = false, defaultValue = "1")
-                    Long memberId,
-                    @Parameter(description = "MALE | FEMALE") @RequestParam(required = false)
-                    Gender gender,
-                    @Parameter(description = "TWO_ON_TWO | THREE_ON_THREE | ...") @RequestParam(required = false)
-                    TeamSize teamSize,
-                    @Parameter(description = "ROMANTIC_TENSION | ...") @RequestParam(required = false)
-                    TeamMood preferredMood,
-                    Pageable pageable) {
+            @Parameter(description = "MALE | FEMALE") @RequestParam(required = false)
+            Gender gender,
+            @Parameter(description = "TWO_ON_TWO | THREE_ON_THREE | ...") @RequestParam(required = false)
+            TeamSize teamSize,
+            @Parameter(description = "ROMANTIC_TENSION | ...") @RequestParam(required = false)
+            TeamMood preferredMood,
+            Pageable pageable) {
 
         Page<TeamResponseDto.TeamMatchPostSummary> response =
-                        teamService.getMatchingPosts(gender, teamSize, preferredMood, pageable);
+                teamService.getMatchingPosts(gender, teamSize, preferredMood, pageable);
 
         return ResponseEntity.ok(BaseResponse.onSuccess(response));
     }
@@ -118,7 +111,7 @@ public class TeamController {
     @Operation(summary = "팀 매칭글 상세 조회", description = "오픈된 팀(매칭글) 상세 정보를 조회합니다.")
     @GetMapping("/matching-posts/{teamId}")
     public ResponseEntity<BaseResponse<TeamResponseDto.TeamMatchPostDetail>> getMatchingPostDetail(
-                    @Parameter(description = "팀(매칭글) ID", required = true) @PathVariable Long teamId) {
+            @Parameter(description = "팀(매칭글) ID", required = true) @PathVariable Long teamId) {
         TeamResponseDto.TeamMatchPostDetail response = teamService.getMatchingPostDetail(teamId);
         return ResponseEntity.ok(BaseResponse.onSuccess(response));
     }
@@ -126,23 +119,20 @@ public class TeamController {
     @Operation(summary = "내가 팀장인 매칭글 수정", description = "팀장만 매칭글을 수정할 수 있습니다. (매칭 성사 전까지만 가능)")
     @PatchMapping("/matching-posts/{teamId}")
     public ResponseEntity<BaseResponse<TeamResponseDto.TeamMatchPostDetail>> updateMatchingPost(
-                    @Parameter(description = "팀장 ID", required = true)
-                    @RequestHeader(value = "X-User-Id", required = false, defaultValue = "1")
-                    Long leaderId,
-                    @Parameter(description = "팀(매칭글) ID", required = true) @PathVariable Long teamId,
-                    @Valid @RequestBody TeamRequestDto.UpdateMatchPostRequest request) {
-        TeamResponseDto.TeamMatchPostDetail response =
-                        teamService.updateMatchingPost(leaderId, teamId, request);
+            @AuthenticationPrincipal AuthUser authUser,
+            @Parameter(description = "팀(매칭글) ID", required = true) @PathVariable Long teamId,
+            @Valid @RequestBody TeamRequestDto.UpdateMatchPostRequest request) {
+        long leaderId = AuthValidator.require(authUser).getId();
+        TeamResponseDto.TeamMatchPostDetail response = teamService.updateMatchingPost(leaderId, teamId, request);
         return ResponseEntity.ok(BaseResponse.onSuccess(response));
     }
 
     @Operation(summary = "내가 팀장인 매칭글 삭제", description = "팀장만 매칭글을 삭제(해체)할 수 있습니다. (매칭 성사 전까지만 가능)")
     @DeleteMapping("/matching-posts/{teamId}")
     public ResponseEntity<BaseResponse<Void>> deleteMatchingPost(
-                    @Parameter(description = "팀장 ID", required = true)
-                    @RequestHeader(value = "X-User-Id", required = false, defaultValue = "1")
-                    Long leaderId,
-                    @Parameter(description = "팀(매칭글) ID", required = true) @PathVariable Long teamId) {
+            @AuthenticationPrincipal AuthUser authUser,
+            @Parameter(description = "팀(매칭글) ID", required = true) @PathVariable Long teamId) {
+        long leaderId = AuthValidator.require(authUser).getId();
         teamService.deleteMatchingPost(leaderId, teamId);
         return ResponseEntity.ok(BaseResponse.onSuccess());
     }


### PR DESCRIPTION
### 📅 Development Period

2026.02.21 ~ 2026.02.21

### 📢 Description

#### 1. `TeamController`, `FriendController`, `MatchRequestController`에서 사용자 식별 헤더(`X-User-Id`) 제거 후 사용자 식별 방식을 `@AuthenticationPrincipal AuthUser` 기반으로 통일

#### 2. Controller 진입 시 `AuthValidator.require(authUser).getId()`를 통해 인증 사용자 검증 및 ID 추출을 일괄 적용

### ✔️ PR Checklist

MR이 아래 사항을 충족하는지 확인해주세요:

- [x] Merge 방향 및 Branch 확인했습니다.
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 코드가 정상적으로 동작하는지 테스트했습니다.

### 🔖 Note
## 1. 반드시 PR #49 (foundation) merge 후 위 PR을 타겟을 `develop`으로 변경하셔서 merge 해주세요.