### PR TITLE
 [🔀 BE] ChatController HTTP API JWT Principal 기반 전환

### DIFF
--- a/src/main/java/com/mini/buting/api/chat/controller/ChatController.java
+++ b/src/main/java/com/mini/buting/api/chat/controller/ChatController.java
@@ -7,6 +7,8 @@ import com.mini.buting.api.chat.service.*;
 import com.mini.buting.api.matchRequest.domain.MatchRequest;
 import com.mini.buting.api.matchRequest.repository.MatchRequestRepository;
 import com.mini.buting.global.response.BaseResponse;
+import com.mini.buting.global.security.principal.AuthUser;
+import com.mini.buting.global.security.util.AuthValidator;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
@@ -20,6 +22,7 @@ import org.springframework.messaging.handler.annotation.DestinationVariable;
 import org.springframework.messaging.handler.annotation.Header;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -61,7 +64,7 @@ public class ChatController {
             description = """
                 채팅방에 입장하며 채팅방 요약 정보, 공지(있으면), 참여 멤버 목록, 초기 메시지 목록을 조회합니다.
                 
-                - `senderId` 헤더로 요청자를 식별합니다.
+                - JWT 인증 사용자 기준으로 요청자를 식별합니다.
                 - `noticeInfo`는 공지가 없으면 null 입니다.
                 - `messages.messages`는 초기 진입 시 비어 있을 수 있습니다.
                 """
@@ -138,8 +141,9 @@ public class ChatController {
                     in = ParameterIn.HEADER,
                     example = "1"
             )
-            @RequestHeader("senderId") Long senderId
-    ){
+            @AuthenticationPrincipal AuthUser authUser
+            ){
+        long senderId = AuthValidator.require(authUser).getId();
         ChatRoomInfoResponse roomInfo = chatRoomService.enterChatroom(roomId, senderId);
 
         return BaseResponse.onSuccess(roomInfo);
@@ -230,7 +234,7 @@ public class ChatController {
                     in = ParameterIn.HEADER,
                     example = "2"
             )
-            @RequestHeader("senderId") Long senderId,
+            @AuthenticationPrincipal AuthUser authUser,
 
             @Parameter(
                     description = """
@@ -243,7 +247,7 @@ public class ChatController {
             )
             @RequestParam(required = false) Long beforeSeq
     ) {
-        return BaseResponse.onSuccess(chatRoomService.getMessages(roomId, senderId, beforeSeq));
+        return BaseResponse.onSuccess(chatRoomService.getMessages(roomId, AuthValidator.require(authUser).getId(), beforeSeq));
     }
 
     // 채팅방 생성 (테스트용. 실서비스에서는 api 없음)
@@ -254,8 +258,6 @@ public class ChatController {
         chatRoomService.sendWelcomeMessage(room.getRoomId(), room.getLeader().getId());
         return room.getRoomId() + " " + room.getTitle();
     }
-
-
 
     @Operation(
             summary = "채팅방 목록 조회",
@@ -309,17 +311,8 @@ public class ChatController {
             )
     })
     @GetMapping
-    public BaseResponse<List<ChatRoomResponse>> getChatRooms(
-            @Parameter(
-                    name = "senderId",
-                    description = "요청자 회원 ID",
-                    required = true,
-                    in = ParameterIn.HEADER,
-                    example = "2"
-            )
-            @RequestHeader("senderId") Long senderId
-    ) {
-        return BaseResponse.onSuccess(chatRoomListService.getChatRooms(senderId));
+    public BaseResponse<List<ChatRoomResponse>> getChatRooms(@AuthenticationPrincipal AuthUser authUser) {
+        return BaseResponse.onSuccess(chatRoomListService.getChatRooms(AuthValidator.require(authUser).getId()));
     }
 
     @Operation(
@@ -363,14 +356,7 @@ public class ChatController {
             )
             @PathVariable String roomId,
 
-            @Parameter(
-                    name = "senderId",
-                    description = "요청자 회원 ID",
-                    required = true,
-                    in = ParameterIn.HEADER,
-                    example = "2"
-            )
-            @RequestHeader("senderId") Long senderId,
+            @AuthenticationPrincipal AuthUser authUser,
 
             @io.swagger.v3.oas.annotations.parameters.RequestBody(
                     required = true,
@@ -390,7 +376,7 @@ public class ChatController {
             @RequestBody ChatRoomUpdateRequest chatRoomUpdateRequest
     ) {
         ChatRoomUpdateResponse updateRoom =
-                chatRoomService.updateChatRoomTitle(roomId, senderId, chatRoomUpdateRequest);
+                chatRoomService.updateChatRoomTitle(roomId, AuthValidator.require(authUser).getId(), chatRoomUpdateRequest);
         return BaseResponse.onSuccess(updateRoom);
     }
 
@@ -465,14 +451,7 @@ public class ChatController {
             )
             @PathVariable String roomId,
 
-            @Parameter(
-                    name = "senderId",
-                    description = "요청자 회원 ID",
-                    required = true,
-                    in = ParameterIn.HEADER,
-                    example = "2"
-            )
-            @RequestHeader("senderId") Long senderId,
+            @AuthenticationPrincipal AuthUser authUser,
 
             @io.swagger.v3.oas.annotations.parameters.RequestBody(
                     required = true,
@@ -493,7 +472,7 @@ public class ChatController {
             )
             @RequestBody NoticeUpsertRequest request
     ) {
-        return BaseResponse.onSuccess(noticeService.upsertNotice(roomId, senderId, request));
+        return BaseResponse.onSuccess(noticeService.upsertNotice(roomId, AuthValidator.require(authUser).getId(), request));
     }
 
     @Operation(
@@ -542,16 +521,9 @@ public class ChatController {
             )
             @PathVariable String roomId,
 
-            @Parameter(
-                    name = "senderId",
-                    description = "요청자 회원 ID",
-                    required = true,
-                    in = ParameterIn.HEADER,
-                    example = "2"
-            )
-            @RequestHeader("senderId") Long senderId
+            @AuthenticationPrincipal AuthUser authUser
     ) {
-        return BaseResponse.onSuccess(noticeService.getNotice(roomId, senderId));
+        return BaseResponse.onSuccess(noticeService.getNotice(roomId, AuthValidator.require(authUser).getId()));
     }
 
     @Operation(
@@ -592,16 +564,9 @@ public class ChatController {
             )
             @PathVariable String roomId,
 
-            @Parameter(
-                    name = "senderId",
-                    description = "요청자 회원 ID",
-                    required = true,
-                    in = ParameterIn.HEADER,
-                    example = "2"
-            )
-            @RequestHeader("senderId") Long senderId
+            @AuthenticationPrincipal AuthUser authUser
     ) {
-        noticeService.delete(roomId, senderId);
+        noticeService.delete(roomId, AuthValidator.require(authUser).getId());
         return BaseResponse.onSuccess();
     }
 
@@ -682,14 +647,7 @@ public class ChatController {
             )
             @PathVariable String roomId,
 
-            @Parameter(
-                    name = "senderId",
-                    description = "요청자 회원 ID",
-                    required = true,
-                    in = ParameterIn.HEADER,
-                    example = "1"
-            )
-            @RequestHeader("senderId") Long senderId,
+            @AuthenticationPrincipal AuthUser authUser,
 
             @io.swagger.v3.oas.annotations.parameters.RequestBody(
                     required = true,
@@ -717,7 +675,7 @@ public class ChatController {
             @RequestBody VoteCreateRequest vote
     ) {
         return BaseResponse.onSuccess(
-                voteService.createVote(roomId, senderId, vote)
+                voteService.createVote(roomId, AuthValidator.require(authUser).getId(), vote)
         );
     }
 
@@ -795,16 +753,9 @@ public class ChatController {
             )
             @PathVariable String voteId,
 
-            @Parameter(
-                    name = "senderId",
-                    description = "요청자 회원 ID",
-                    required = true,
-                    in = ParameterIn.HEADER,
-                    example = "2"
-            )
-            @RequestHeader("senderId") Long senderId
+            @AuthenticationPrincipal AuthUser authUser
     ) {
-        return BaseResponse.onSuccess(voteService.getVoteInfo(roomId, voteId, senderId));
+        return BaseResponse.onSuccess(voteService.getVoteInfo(roomId, voteId, AuthValidator.require(authUser).getId()));
     }
 
 
@@ -884,14 +835,7 @@ public class ChatController {
             )
             @PathVariable String voteId,
 
-            @Parameter(
-                    name = "senderId",
-                    description = "요청자 회원 ID",
-                    required = true,
-                    in = ParameterIn.HEADER,
-                    example = "2"
-            )
-            @RequestHeader("senderId") Long senderId,
+            @AuthenticationPrincipal AuthUser authUser,
 
             @io.swagger.v3.oas.annotations.parameters.RequestBody(
                     required = true,
@@ -911,7 +855,7 @@ public class ChatController {
             @RequestBody VoteBallotCreateRequest vote
     ) {
         return BaseResponse.onSuccess(
-                voteService.vote(roomId, voteId, senderId, vote)
+                voteService.vote(roomId, voteId, AuthValidator.require(authUser).getId(), vote)
         );
     }
 
@@ -959,16 +903,9 @@ public class ChatController {
             )
             @PathVariable String voteId,
 
-            @Parameter(
-                    name = "senderId",
-                    description = "요청자 회원 ID",
-                    required = true,
-                    in = ParameterIn.HEADER,
-                    example = "1"
-            )
-            @RequestHeader("senderId") Long senderId
+            @AuthenticationPrincipal AuthUser authUser
     ) {
-        voteService.deleteVote(roomId, voteId, senderId);
+        voteService.deleteVote(roomId, voteId, AuthValidator.require(authUser).getId());
         return BaseResponse.onSuccess();
     }
 


### PR DESCRIPTION
### 📅 Development Period

2026.02.21 ~ 2026.02.21

### 📢 Description

- `ChatController`의 **HTTP API** 사용자 식별 방식을 `senderId` 헤더 기반에서 `@AuthenticationPrincipal AuthUser` 기반으로 전환
- 인증 사용자 추출은 `AuthValidator.require(authUser).getId()`로 일괄 적용
- 채팅/공지/투표 관련 HTTP 엔드포인트 전반에서 `senderId` 헤더 의존을 제거함

#### 범위
- 포함: Chat HTTP 엔드포인트 (`@GetMapping/@PostMapping/@PutMapping/@DeleteMapping`) 
- **미포함: STOMP/WebSocket(`@MessageMapping`)** 

### ✔️ PR Checklist

MR이 아래 사항을 충족하는지 확인해주세요:

- [x] Merge 방향 및 Branch 확인했습니다.
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 코드가 정상적으로 동작하는지 테스트했습니다.

### 🔖 Note
## 1. 반드시 PR #49 (foundation) merge 후 위 PR을 타겟을 `develop`으로 변경하셔서 merge 해주세요.

## 2. ‼️ STOMP 구간(`@MessageMapping`, `@Header("senderId")`)은 아직 안 건드렸습니다 ‼️
- JWT 기반 파싱/인증 코드를 추가해야 합니다...
- STOMP 담당자(@yoonsu0325)가 JWT 파싱 로직 구현을 이어서 진행 가능하신지 연락 부탁드립니답 (여유가 안 되면 제가 진행하겠습니다).