### PR TITLE
[🚑️ BE] 회원 가용성 체크 이메일 중복 기준 오류 수정

### DIFF
--- a/src/main/java/com/mini/buting/api/member/repository/MemberRepository.java
+++ b/src/main/java/com/mini/buting/api/member/repository/MemberRepository.java
@@ -1,5 +1,6 @@
 package com.mini.buting.api.member.repository;
 
+import com.mini.buting.api.auth.dto.response.MemberAvailabilityResponse;
 import com.mini.buting.api.member.domain.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -85,4 +86,13 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     boolean existsActiveById(@Param("memberId") Long memberId);
 
     boolean existsByNicknameAndIsDeletedFalse(String nickname);
+
+    /**
+     * 대학 이메일(local-part + domain) 기준 활성 회원 존재 여부 확인
+     *
+     * @param universityEmail local-part
+     * @param domain          도메인
+     * @return 존재하면 true
+     */
+    boolean existsByUniversityEmailAndUniversityDomain_DomainAndIsDeletedFalse(String universityEmail, String domain);
 }

--- a/src/main/java/com/mini/buting/api/member/service/MemberService.java
+++ b/src/main/java/com/mini/buting/api/member/service/MemberService.java
@@ -5,6 +5,7 @@ import com.mini.buting.api.member.domain.Member;
 import com.mini.buting.api.member.dto.MemberProfileResponse;
 import com.mini.buting.api.member.repository.MemberRepository;
 import com.mini.buting.api.member.repository.MemberSocialRepository;
+import com.mini.buting.api.university.util.UniversityEmailParser;
 import com.mini.buting.global.exception.BaseException;
 import com.mini.buting.global.response.BaseResponseStatus;
 import lombok.RequiredArgsConstructor;
@@ -23,7 +24,7 @@ import java.util.List;
 public class MemberService {
 
     private final MemberRepository memberRepository;
-    private final MemberSocialRepository memberSocialRepository;
+    private final UniversityEmailParser universityEmailParser;
 
     /**
      * 회원 프로필 조회
@@ -88,7 +89,10 @@ public class MemberService {
         List<MemberAvailabilityResponse> responses = new ArrayList<>();
 
         if (hasEmail) {
-            boolean isDuplicated = memberSocialRepository.existsByEmailAndMember_IsDeletedFalse(email);
+            String normalizedEmail = universityEmailParser.normalize(email);
+            String localPart = universityEmailParser.extractLocalPart(normalizedEmail);
+            String domain = universityEmailParser.extractDomain(normalizedEmail);
+            boolean isDuplicated = memberRepository.existsByUniversityEmailAndUniversityDomain_DomainAndIsDeletedFalse(localPart, domain);
             responses.add(MemberAvailabilityResponse.of(MemberAvailabilityResponse.AvailabilityType.EMAIL, email, !isDuplicated));
         }
 


### PR DESCRIPTION
<!--
🚑️ Hotfix MR (제목을 입력해주세요)

📌 사용 예시:
[🚑️ BE] 배포 후 500 오류 수정
[🚑️ FE] 회원가입 시 닉네임 중복 체크 오류 해결

⚠️ (괄호) 항목은 모두 지우고 알맞게 작성해주세요.
-->

### 🔗 Connected Issue

Closes miniPJT-BuTing/buting#(이슈번호)

### 📅 Development Period

<!-- 작업 기간을 YYYY.MM.DD ~ YYYY.MM.DD 형식으로 입력해주세요 -->

2026.02.21 ~ 2026.02.21

### 📢 Description

#### (1) 배경
- `/v1/members/availability?email=...` 호출 시 이미 가입된 대학 이메일이어도 `isAvailable: true`가 반환되는 문제가 있었음.
- 원인은 중복 판정이 `member_social.email` 기준으로 동작해 실제 회원가입 제약(`member.university_email + university_domain`)과 불일치했기 때문임.

#### (2) 변경 사항
##### 이메일 가용성 체크 기준 변경
- 기존: `member_social.email` 중복 확인
- 변경: `member.university_email + university_domain.domain + is_deleted=false` 중복 확인

<!-- 작업 내용을 명확하게 설명해주세요 -->

### ✔️ PR Checklist

MR이 아래 사항을 충족하는지 확인해주세요:

- [x] Merge 방향 (hotfix → release, hotfix → develop) 확인했습니다.
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 코드가 정상적으로 동작하는지 테스트했습니다.