### PR TITLE
[🚑️ BE] OAuth2 Kakao Redirect URI 고정 및 forwarded header 처리 개선

### DIFF
--- a/src/main/resources/application-auth.yaml
+++ b/src/main/resources/application-auth.yaml
@@ -6,7 +6,7 @@ spring:
           kakao:
             client-id: ${OAUTH2_REGISTRATION_KAKAO_CLIENT_ID}
             client-secret:  ${OAUTH2_REGISTRATION_KAKAO_CLIENT_SECRET}
-            redirect-uri: "{baseUrl}${SECURITY_OAUTH_REDIRECTION_BASE}/{registrationId}"
+            redirect-uri: ${OAUTH2_REGISTRATION_KAKAO_REDIRECT_URI}
             authorization-grant-type: authorization_code
             client-authentication-method: client_secret_post
             client-name: Kakao

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -6,6 +6,7 @@ server:
       secure: ${SERVER_COOKIE_SECURE:false}
       same-site: ${SERVER_COOKIE_SAMESITE:Lax}
       domain: ${SERVER_COOKIE_DOMAIN:}
+  forward-headers-strategy: framework
 
 swagger:
   uri: ${SWAGGER_URI}


### PR DESCRIPTION
### 📅 Development Period

<!-- 작업 기간을 YYYY.MM.DD ~ YYYY.MM.DD 형식으로 입력해주세요 -->

2026.02.22 ~ 2026.02.22

### 📢 Description

#### (1) 배경
- 배포 환경에서 Kakao OAuth redirect URI가 `http://.../v1/...` 형태롤 생성되어, 기대값인 `https://.../api/v1...`와 불일치하는 문제가 발생함.

#### (2) 변경사항
- `application-auth.yaml`
  - `spring.security.oauth2.client.registration.kakao.redirect-uri`
    - 기존: `{baseUri}${SECURITY_OAUTH_REDIRECTION_BASE}/{registrationId}`
    - 변경: `${OAUTH2_REGISTRATION_KAKAO_REDIRECT_URI}`
- `application.yaml`
  - `server.forward-headers-strategy: framework` 추가

<!-- 작업 내용을 명확하게 설명해주세요 -->

### ✔️ PR Checklist

MR이 아래 사항을 충족하는지 확인해주세요:

- [x] Merge 방향 (hotfix → release, hotfix → develop) 확인했습니다.
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 코드가 정상적으로 동작하는지 테스트했습니다.

### 🔖 Note

<!-- 참고사항을 적어주세요 -->
배포환경 환경변수(`.env`) 파일 업데이트 완료 (바로 merge 하시면 됩니다)