### PR TITLE
[🔀 BE] AI 얼굴 분석 API 분리 및 회원 faceShape 저장 로직 반영

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,11 @@ dependencies {
     annotationProcessor "jakarta.annotation:jakarta.annotation-api"
     annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 
+    // == JWT ==
+    implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
+    implementation 'io.jsonwebtoken:jjwt-impl:0.12.6'
+    implementation 'io.jsonwebtoken:jjwt-jackson:0.12.6'
+
     // === Developer Tools & Utilities ===
     // Lombok
     compileOnly 'org.projectlombok:lombok'

--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-websocket'
     implementation 'org.springframework.boot:spring-boot-starter-amqp'
     implementation "org.springframework.boot:spring-boot-starter-reactor-netty"
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
     implementation 'org.springframework.boot:spring-boot-starter-mail'
@@ -41,11 +42,6 @@ dependencies {
     annotationProcessor 'com.querydsl:querydsl-apt:5.1.0:jakarta'
     annotationProcessor "jakarta.annotation:jakarta.annotation-api"
     annotationProcessor "jakarta.persistence:jakarta.persistence-api"
-
-    // == JWT ==
-    implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
-    implementation 'io.jsonwebtoken:jjwt-impl:0.12.6'
-    implementation 'io.jsonwebtoken:jjwt-jackson:0.12.6'
 
     // === Developer Tools & Utilities ===
     // Lombok

--- a/src/main/java/com/mini/buting/api/analysis/controller/AiController.java
+++ b/src/main/java/com/mini/buting/api/analysis/controller/AiController.java
@@ -1,0 +1,75 @@
+package com.mini.buting.api.analysis.controller;
+
+import com.mini.buting.api.analysis.domain.FaceShape;
+import com.mini.buting.api.analysis.dto.request.AiFastapiRequest;
+
+import com.mini.buting.api.analysis.dto.response.AiFastapiResponse;
+import com.mini.buting.api.analysis.dto.response.AiResponse;
+import com.mini.buting.api.analysis.repository.FaceShapeRepository;
+import com.mini.buting.api.analysis.service.AiService;
+import com.mini.buting.api.member.domain.Gender;
+import com.mini.buting.api.member.dto.MemberProfileResponse;
+import com.mini.buting.api.member.service.MemberService;
+import com.mini.buting.global.response.BaseResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/v1/ai")
+public class AiController {
+
+    private final AiService aiService;
+    private final MemberService memberService;
+    private final FaceShapeRepository faceShapeRepository;
+
+    @Operation(
+            summary = "AI 얼굴 동물상 분석",
+            description = "이미지 파일을 업로드하면 AI 분석을 통해 동물상 결과를 반환합니다."
+    )
+    @ApiResponse(
+            responseCode = "200",
+            description = "AI 분석 성공",
+            content = @Content(
+                    mediaType = "application/json"
+            )
+    )
+    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public BaseResponse<AiResponse> getAiAnalysis(
+
+            @Parameter(
+                    description = "사용자 ID",
+                    example = "1"
+            )
+            @RequestHeader(value = "X-User-Id", required = false, defaultValue = "1")
+            Long userId,
+
+            @Parameter(
+                    description = "분석할 얼굴 이미지 파일",
+                    required = true,
+                    content = @Content(
+                            mediaType = MediaType.MULTIPART_FORM_DATA_VALUE
+                    )
+            )
+            @RequestPart("file")
+            MultipartFile file
+    ) {
+
+        MemberProfileResponse memberProfile = memberService.getMemberProfile(userId);
+        String gender = memberProfile.getGender().equals(Gender.M) ? "남자" : "여자";
+
+        AiFastapiResponse result = aiService.analyzeAnimal(new AiFastapiRequest(gender, file));
+
+        FaceShape faceShape = faceShapeRepository.findByName(result.getAnimalType());
+        AiResponse aiResponse = AiResponse.from(faceShape, result.getDetScore());
+
+        return BaseResponse.onSuccess(aiResponse);
+    }
+
+}

--- a/src/main/java/com/mini/buting/api/analysis/controller/AiController.java
+++ b/src/main/java/com/mini/buting/api/analysis/controller/AiController.java
@@ -1,9 +1,5 @@
 package com.mini.buting.api.analysis.controller;
 
-import com.mini.buting.api.analysis.domain.FaceShape;
-import com.mini.buting.api.analysis.dto.request.AiFastapiRequest;
-
-import com.mini.buting.api.analysis.dto.response.AiFastapiResponse;
 import com.mini.buting.api.analysis.dto.response.AiResponse;
 import com.mini.buting.api.analysis.repository.FaceShapeRepository;
 import com.mini.buting.api.analysis.service.AiService;
@@ -11,28 +7,42 @@ import com.mini.buting.api.member.domain.Gender;
 import com.mini.buting.api.member.dto.MemberProfileResponse;
 import com.mini.buting.api.member.service.MemberService;
 import com.mini.buting.global.response.BaseResponse;
+import com.mini.buting.global.security.principal.AuthUser;
+import com.mini.buting.global.security.util.AuthValidator;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
+/**
+ * <h2>AI 얼굴 분석 API Controller</h2>
+ */
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/v1/ai")
 public class AiController {
 
     private final AiService aiService;
-    private final MemberService memberService;
-    private final FaceShapeRepository faceShapeRepository;
 
-    @Operation(
-            summary = "AI 얼굴 동물상 분석",
-            description = "이미지 파일을 업로드하면 AI 분석을 통해 동물상 결과를 반환합니다."
-    )
+    @Operation(summary = "AI 얼굴 동물상 분석(비인증/회원가입용)")
+    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public BaseResponse<AiResponse> analyzeForGuest(
+            @Parameter(description = "성별(M/F)", required = true)
+            @RequestParam("gender") Gender gender,
+
+            @Parameter(description = "분석할 얼굴 이미지 파일", required = true, content = @Content(mediaType = MediaType.MULTIPART_FORM_DATA_VALUE))
+            @RequestPart("file") MultipartFile file
+    ) {
+        String genderText = gender.equals(Gender.M) ? "남자" : "여자";
+        return BaseResponse.onSuccess(aiService.analyzeFaceShape(genderText, file));
+    }
+
+    @Operation(summary = "AI 얼굴 동물상 분석(회원 전용, 결과 저장)")
     @ApiResponse(
             responseCode = "200",
             description = "AI 분석 성공",
@@ -40,15 +50,9 @@ public class AiController {
                     mediaType = "application/json"
             )
     )
-    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @PostMapping(value = "/me", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public BaseResponse<AiResponse> getAiAnalysis(
-
-            @Parameter(
-                    description = "사용자 ID",
-                    example = "1"
-            )
-            @RequestHeader(value = "X-User-Id", required = false, defaultValue = "1")
-            Long userId,
+            @AuthenticationPrincipal AuthUser authUser,
 
             @Parameter(
                     description = "분석할 얼굴 이미지 파일",
@@ -60,16 +64,8 @@ public class AiController {
             @RequestPart("file")
             MultipartFile file
     ) {
-
-        MemberProfileResponse memberProfile = memberService.getMemberProfile(userId);
-        String gender = memberProfile.getGender().equals(Gender.M) ? "남자" : "여자";
-
-        AiFastapiResponse result = aiService.analyzeAnimal(new AiFastapiRequest(gender, file));
-
-        FaceShape faceShape = faceShapeRepository.findByName(result.getAnimalType());
-        AiResponse aiResponse = AiResponse.from(faceShape, result.getDetScore());
-
-        return BaseResponse.onSuccess(aiResponse);
+        long memberId = AuthValidator.require(authUser).getId();
+        return BaseResponse.onSuccess(aiService.analyzeFaceShapeAndUpdateMember(memberId, file));
     }
 
 }

--- a/src/main/java/com/mini/buting/api/analysis/domain/FaceShape.java
+++ b/src/main/java/com/mini/buting/api/analysis/domain/FaceShape.java
@@ -23,4 +23,16 @@ public class FaceShape extends BaseTimeEntity {
     @Column(name = "name", nullable = false, length = 30)
     @Comment("얼굴형 명칭 (예: 강아지상, 고양이상)")
     private String name;
+
+    @Column(name = "nickname", nullable = false, length = 30)
+    @Comment("얼굴형 별칭 (예: 복실복실 강아지상)")
+    private String nickname;
+
+    @Column(name = "description", nullable = false, length = 200)
+    @Comment("닮은 동물 특징 설명")
+    private String description;
+
+    @Column(name = "image", nullable = false, length = 200)
+    @Comment("닮은 동물 사진 S3 URL")
+    private String image;
 }

--- a/src/main/java/com/mini/buting/api/analysis/dto/request/AiFastapiRequest.java
+++ b/src/main/java/com/mini/buting/api/analysis/dto/request/AiFastapiRequest.java
@@ -1,0 +1,9 @@
+package com.mini.buting.api.analysis.dto.request;
+
+import org.springframework.web.multipart.MultipartFile;
+
+public record AiFastapiRequest (
+
+    String gender,
+    MultipartFile file
+){}

--- a/src/main/java/com/mini/buting/api/analysis/dto/request/AiRequest.java
+++ b/src/main/java/com/mini/buting/api/analysis/dto/request/AiRequest.java
@@ -1,0 +1,8 @@
+package com.mini.buting.api.analysis.dto.request;
+
+import org.springframework.web.multipart.MultipartFile;
+
+public record AiRequest(
+        MultipartFile file
+) {
+}

--- a/src/main/java/com/mini/buting/api/analysis/dto/response/AiFastapiResponse.java
+++ b/src/main/java/com/mini/buting/api/analysis/dto/response/AiFastapiResponse.java
@@ -1,0 +1,14 @@
+package com.mini.buting.api.analysis.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+
+@Getter
+public class AiFastapiResponse {
+
+    @JsonProperty("animal_type")
+    String animalType;
+
+    @JsonProperty("det_score")
+    Double detScore;
+}

--- a/src/main/java/com/mini/buting/api/analysis/dto/response/AiResponse.java
+++ b/src/main/java/com/mini/buting/api/analysis/dto/response/AiResponse.java
@@ -1,0 +1,24 @@
+package com.mini.buting.api.analysis.dto.response;
+
+import com.mini.buting.api.analysis.domain.FaceShape;
+
+public record AiResponse(
+        Long id,
+        String name,
+        String nickname,
+        String description,
+        String image,
+        Double percentage
+) {
+
+    public static AiResponse from(FaceShape faceShape, Double percentage){
+        return new AiResponse(
+                faceShape.getId(),
+                faceShape.getName(),
+                faceShape.getNickname(),
+                faceShape.getDescription(),
+                faceShape.getImage(),
+                percentage
+        );
+    }
+}

--- a/src/main/java/com/mini/buting/api/analysis/dto/response/AiResponse.java
+++ b/src/main/java/com/mini/buting/api/analysis/dto/response/AiResponse.java
@@ -3,7 +3,7 @@ package com.mini.buting.api.analysis.dto.response;
 import com.mini.buting.api.analysis.domain.FaceShape;
 
 public record AiResponse(
-        Long id,
+        Long faceShapeId,
         String name,
         String nickname,
         String description,

--- a/src/main/java/com/mini/buting/api/analysis/repository/FaceShapeRepository.java
+++ b/src/main/java/com/mini/buting/api/analysis/repository/FaceShapeRepository.java
@@ -4,7 +4,9 @@ import com.mini.buting.api.analysis.domain.FaceShape;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface FaceShapeRepository extends JpaRepository<FaceShape, Long> {
-    FaceShape findByName(String animalType);
+    Optional<FaceShape> findByName(String animalType);
 }

--- a/src/main/java/com/mini/buting/api/analysis/repository/FaceShapeRepository.java
+++ b/src/main/java/com/mini/buting/api/analysis/repository/FaceShapeRepository.java
@@ -6,4 +6,5 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface FaceShapeRepository extends JpaRepository<FaceShape, Long> {
+    FaceShape findByName(String animalType);
 }

--- a/src/main/java/com/mini/buting/api/analysis/service/AiService.java
+++ b/src/main/java/com/mini/buting/api/analysis/service/AiService.java
@@ -16,6 +16,7 @@ import org.springframework.core.io.ByteArrayResource;
 import org.springframework.http.MediaType;
 import org.springframework.http.client.MultipartBodyBuilder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.reactive.function.BodyInserters;
 import org.springframework.web.reactive.function.client.WebClient;
@@ -24,6 +25,7 @@ import reactor.core.publisher.Mono;
 @Service
 @Slf4j
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class AiService {
 
     private final WebClient fastApiWebClient;
@@ -43,12 +45,15 @@ public class AiService {
     /**
      * 회원 기준으로 분석 수행 후 faceShape를 회원 정보에 저장
      */
+    @Transactional
     public AiResponse analyzeFaceShapeAndUpdateMember(Long memberId, MultipartFile file) {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new BaseException(BaseResponseStatus.MEMBER_NOT_FOUND));
 
         String gender = member.getGender().equals(Gender.M) ? "남자" : "여자";
         AiFastapiResponse result = requestFastApiAnalysis(new AiFastapiRequest(gender, file));
+        String animalType = result.getAnimalType();
+        log.info("[AI] normalized='{}'", animalType == null ? null : animalType.trim());
         FaceShape faceShape = resolveFaceShape(result.getAnimalType());
 
         member.updateFaceShape(faceShape);

--- a/src/main/java/com/mini/buting/api/analysis/service/AiService.java
+++ b/src/main/java/com/mini/buting/api/analysis/service/AiService.java
@@ -1,7 +1,13 @@
 package com.mini.buting.api.analysis.service;
 
+import com.mini.buting.api.analysis.domain.FaceShape;
 import com.mini.buting.api.analysis.dto.request.AiFastapiRequest;
 import com.mini.buting.api.analysis.dto.response.AiFastapiResponse;
+import com.mini.buting.api.analysis.dto.response.AiResponse;
+import com.mini.buting.api.analysis.repository.FaceShapeRepository;
+import com.mini.buting.api.member.domain.Gender;
+import com.mini.buting.api.member.domain.Member;
+import com.mini.buting.api.member.repository.MemberRepository;
 import com.mini.buting.global.exception.BaseException;
 import com.mini.buting.global.response.BaseResponseStatus;
 import lombok.RequiredArgsConstructor;
@@ -10,6 +16,7 @@ import org.springframework.core.io.ByteArrayResource;
 import org.springframework.http.MediaType;
 import org.springframework.http.client.MultipartBodyBuilder;
 import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.reactive.function.BodyInserters;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
@@ -20,11 +27,39 @@ import reactor.core.publisher.Mono;
 public class AiService {
 
     private final WebClient fastApiWebClient;
+    private final FaceShapeRepository faceShapeRepository;
+    private final MemberRepository memberRepository;
 
-    public AiFastapiResponse analyzeAnimal(AiFastapiRequest req) {
+    /**
+     * 성별/파일 기반 분석 결과 반환(저장 없음)
+     */
+    public AiResponse analyzeFaceShape(String gender, MultipartFile file) {
+        AiFastapiResponse result = requestFastApiAnalysis(new AiFastapiRequest(gender, file));
 
+        FaceShape faceShape = resolveFaceShape(result.getAnimalType());
+        return AiResponse.from(faceShape, result.getDetScore());
+    }
+
+    /**
+     * 회원 기준으로 분석 수행 후 faceShape를 회원 정보에 저장
+     */
+    public AiResponse analyzeFaceShapeAndUpdateMember(Long memberId, MultipartFile file) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new BaseException(BaseResponseStatus.MEMBER_NOT_FOUND));
+
+        String gender = member.getGender().equals(Gender.M) ? "남자" : "여자";
+        AiFastapiResponse result = requestFastApiAnalysis(new AiFastapiRequest(gender, file));
+        FaceShape faceShape = resolveFaceShape(result.getAnimalType());
+
+        member.updateFaceShape(faceShape);
+        return AiResponse.from(faceShape, result.getDetScore());
+    }
+
+    /**
+     * FastAPI 분석 요청
+     */
+    private AiFastapiResponse requestFastApiAnalysis(AiFastapiRequest req) {
         MultipartBodyBuilder builder = new MultipartBodyBuilder();
-
         builder.part("gender", req.gender());
 
         try {
@@ -34,9 +69,7 @@ public class AiService {
                     return req.file().getOriginalFilename();
                 }
             };
-
-            builder.part("file", fileResource)
-                    .contentType(MediaType.APPLICATION_OCTET_STREAM);
+            builder.part("file", fileResource).contentType(MediaType.APPLICATION_OCTET_STREAM);
         } catch (Exception e) {
             throw new BaseException(BaseResponseStatus.READ_FILE_FAIL);
         }
@@ -55,5 +88,10 @@ public class AiService {
                 )
                 .bodyToMono(AiFastapiResponse.class)
                 .block();
+    }
+
+    private FaceShape resolveFaceShape(String animalType) {
+        return faceShapeRepository.findByName(animalType.trim())
+                .orElseThrow(() -> new BaseException(BaseResponseStatus.UNSUPPORTED_FACE_SHAPE_TYPE));
     }
 }

--- a/src/main/java/com/mini/buting/api/analysis/service/AiService.java
+++ b/src/main/java/com/mini/buting/api/analysis/service/AiService.java
@@ -1,0 +1,59 @@
+package com.mini.buting.api.analysis.service;
+
+import com.mini.buting.api.analysis.dto.request.AiFastapiRequest;
+import com.mini.buting.api.analysis.dto.response.AiFastapiResponse;
+import com.mini.buting.global.exception.BaseException;
+import com.mini.buting.global.response.BaseResponseStatus;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.http.MediaType;
+import org.springframework.http.client.MultipartBodyBuilder;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.BodyInserters;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class AiService {
+
+    private final WebClient fastApiWebClient;
+
+    public AiFastapiResponse analyzeAnimal(AiFastapiRequest req) {
+
+        MultipartBodyBuilder builder = new MultipartBodyBuilder();
+
+        builder.part("gender", req.gender());
+
+        try {
+            ByteArrayResource fileResource = new ByteArrayResource(req.file().getBytes()) {
+                @Override
+                public String getFilename() {
+                    return req.file().getOriginalFilename();
+                }
+            };
+
+            builder.part("file", fileResource)
+                    .contentType(MediaType.APPLICATION_OCTET_STREAM);
+        } catch (Exception e) {
+            throw new BaseException(BaseResponseStatus.READ_FILE_FAIL);
+        }
+
+        return fastApiWebClient.post()
+                .uri("/fastapi/analyze")
+                .contentType(MediaType.MULTIPART_FORM_DATA)
+                .body(BodyInserters.fromMultipartData(builder.build()))
+                .retrieve()
+                .onStatus(
+                        status -> status.isError(),
+                        clientResponse -> clientResponse.bodyToMono(String.class)
+                                .flatMap(errorBody -> Mono.error(
+                                        new BaseException(BaseResponseStatus.FAST_API_FAIL)
+                                ))
+                )
+                .bodyToMono(AiFastapiResponse.class)
+                .block();
+    }
+}

--- a/src/main/java/com/mini/buting/api/member/domain/Member.java
+++ b/src/main/java/com/mini/buting/api/member/domain/Member.java
@@ -270,4 +270,10 @@ public class Member extends BaseTimeEntity {
     public String getFaceShapeName() {
         return this.faceShape != null ? this.faceShape.getName() : null;
     }
+
+    public void updateFaceShape(FaceShape faceShape) {
+        if (faceShape != null) {
+            this.faceShape = faceShape;
+        }
+    }
 }

--- a/src/main/java/com/mini/buting/global/config/WebClientConfig.java
+++ b/src/main/java/com/mini/buting/global/config/WebClientConfig.java
@@ -1,0 +1,56 @@
+package com.mini.buting.global.config;
+
+import io.netty.channel.ChannelOption;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.client.reactive.ReactorClientHttpConnector;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.util.DefaultUriBuilderFactory;
+import reactor.netty.http.client.HttpClient;
+import reactor.netty.resources.ConnectionProvider;
+
+import java.time.Duration;
+
+
+@Configuration
+public class WebClientConfig {
+
+    @Value("${fastapi.url}")
+    private String FASTAPI_URI;
+
+    DefaultUriBuilderFactory factory = new DefaultUriBuilderFactory();
+
+    HttpClient httpClient = HttpClient.create()
+            .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 10000); // 10초
+
+    @Bean
+    public WebClient webClient() {
+        factory.setEncodingMode(DefaultUriBuilderFactory.EncodingMode.VALUES_ONLY);
+        return WebClient.builder()
+                .uriBuilderFactory(factory)
+                .codecs(configurer -> configurer.defaultCodecs().maxInMemorySize(2 * 1024 * 1024))
+                .clientConnector(new ReactorClientHttpConnector(httpClient))
+                .build();
+    }
+
+    @Bean
+    public ConnectionProvider connectionProvider() {
+        return ConnectionProvider.builder("http-pool")
+                .maxConnections(100)
+                .pendingAcquireTimeout(Duration.ofMillis(0))
+                .pendingAcquireMaxCount(-1)
+                .maxIdleTime(Duration.ofMillis(1000L))
+                .build();
+    }
+
+    @Bean
+    public WebClient fastApiWebClient(WebClient.Builder builder) {
+        return builder
+                .baseUrl(FASTAPI_URI)
+                .defaultHeader(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE)
+                .build();
+    }
+}

--- a/src/main/java/com/mini/buting/global/response/BaseResponseStatus.java
+++ b/src/main/java/com/mini/buting/global/response/BaseResponseStatus.java
@@ -83,7 +83,11 @@ public enum BaseResponseStatus {
      */
     MATCH_REQUEST_NOT_PENDING(HttpStatus.BAD_REQUEST, false, 4001, "대기 중인 매칭 요청이 아닙니다."),
     MATCH_REQUEST_EXPIRED(HttpStatus.BAD_REQUEST, false, 4002, "만료된 매칭 요청입니다."),
-    MATCH_REQUEST_NOT_ACCEPTED(HttpStatus.BAD_REQUEST, false, 4001, "수락 된 매칭 요청이 아닙니다."),
+    MATCH_REQUEST_NOT_ACCEPTED(HttpStatus.BAD_REQUEST, false, 4003, "수락 된 매칭 요청이 아닙니다."),
+    MATCH_REQUEST_NOT_FOUND(HttpStatus.NOT_FOUND, false, 4004, "매칭 요청을 찾을 수 없습니다."),
+    MATCH_REQUEST_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, false, 4005, "이미 존재하는 매칭 요청입니다."),
+    MATCH_REQUEST_SELF(HttpStatus.BAD_REQUEST, false, 4006, "같은 팀으로는 매칭 요청을 보낼 수 없습니다."),
+    MATCH_REQUEST_SAME_GENDER(HttpStatus.BAD_REQUEST, false, 4007, "같은 성별 팀과는 매칭할 수 없습니다."),
     /**
      * 4100: MBTI 관련 에러
      */
@@ -123,6 +127,7 @@ public enum BaseResponseStatus {
     TEAM_SIZE_MISMATCH(HttpStatus.BAD_REQUEST, false, 4503, "초대할 멤버 수가 팀 크기와 일치하지 않습니다."),
     DIFFERENT_GENDER_CANNOT_INVITE(HttpStatus.BAD_REQUEST, false, 4504, "다른 성별의 사용자는 초대할 수 없습니다."),
     TEAM_NOT_READY(HttpStatus.BAD_REQUEST, false, 4505, "모든 멤버가 수락해야 팀이 활성화됩니다."),
+    TEAM_ALREADY_MATCHED(HttpStatus.BAD_REQUEST, false, 4506, "매칭이 성사된 팀은 수정/삭제할 수 없습니다."),
 
     /**
      * 5000: 채팅방 관련 에러
@@ -139,7 +144,24 @@ public enum BaseResponseStatus {
     VOTE_NOT_AVAILABLE(HttpStatus.FORBIDDEN, false, 5010, "투표가 불가능합니다."),
     VOTE_OPTION_REQUIRED(HttpStatus.BAD_REQUEST, false, 5011, "옵션을 하나 이상 선택해야합니다."),
     VOTE_NOT_MULTIPLE(HttpStatus.BAD_REQUEST, false, 5012, "단일 투표에서 중복 투표는 불가능합니다."),
-    INVALID_VOTE_OPTION(HttpStatus.BAD_REQUEST, false, 5013, "해당 투표의 옵션ID가 아닙니다.");
+    INVALID_VOTE_OPTION(HttpStatus.BAD_REQUEST, false, 5013, "해당 투표의 옵션ID가 아닙니다."),
+
+    /**
+     * 6000: FastAPI Analysis 관련 에러
+     */
+    READ_FILE_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, false, 6001, "파일을 읽는데 실패했습니다."),
+    FAST_API_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, false, 6002, "AI 분석에 실패했습니다."),
+
+    /**
+     * 8000: SMTP(메일) 관련 에러
+     */
+    UNSUPPORTED_MAIL_TYPE(HttpStatus.BAD_REQUEST, false, 8000, "지원하지 않는 메일 타입입니다."),
+    MAIL_VERIFICATION_COOLDOWN(HttpStatus.TOO_MANY_REQUESTS, false, 8001, "인증코드 재요청이 너무 빠릅니다."),
+    MAIL_VERIFICATION_ATTEMPTS_EXCEEDED(HttpStatus.TOO_MANY_REQUESTS, false, 8002, "인증코드 입력 횟수를 초과했습니다."),
+    MAIL_VERIFICATION_MISMATCH(HttpStatus.BAD_REQUEST, false, 8003, "인증코드가 일치하지 않습니다."),
+    MAIL_VERIFICATION_EXPIRED(HttpStatus.BAD_REQUEST, false, 8004, "인증코드가 만료되었거나 존재하지 않습니다."),
+    MAIL_VERIFICATION_REQUIRED(HttpStatus.BAD_REQUEST, false, 8005, "이메일 인증이 필요합니다."),
+    MAIL_SEND_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, false, 8500, "메일 발송에 실패했습니다.");
 
 
     private final HttpStatusCode httpStatusCode;

--- a/src/main/java/com/mini/buting/global/response/BaseResponseStatus.java
+++ b/src/main/java/com/mini/buting/global/response/BaseResponseStatus.java
@@ -83,11 +83,7 @@ public enum BaseResponseStatus {
      */
     MATCH_REQUEST_NOT_PENDING(HttpStatus.BAD_REQUEST, false, 4001, "대기 중인 매칭 요청이 아닙니다."),
     MATCH_REQUEST_EXPIRED(HttpStatus.BAD_REQUEST, false, 4002, "만료된 매칭 요청입니다."),
-    MATCH_REQUEST_NOT_ACCEPTED(HttpStatus.BAD_REQUEST, false, 4003, "수락 된 매칭 요청이 아닙니다."),
-    MATCH_REQUEST_NOT_FOUND(HttpStatus.NOT_FOUND, false, 4004, "매칭 요청을 찾을 수 없습니다."),
-    MATCH_REQUEST_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, false, 4005, "이미 존재하는 매칭 요청입니다."),
-    MATCH_REQUEST_SELF(HttpStatus.BAD_REQUEST, false, 4006, "같은 팀으로는 매칭 요청을 보낼 수 없습니다."),
-    MATCH_REQUEST_SAME_GENDER(HttpStatus.BAD_REQUEST, false, 4007, "같은 성별 팀과는 매칭할 수 없습니다."),
+    MATCH_REQUEST_NOT_ACCEPTED(HttpStatus.BAD_REQUEST, false, 4001, "수락 된 매칭 요청이 아닙니다."),
     /**
      * 4100: MBTI 관련 에러
      */
@@ -127,7 +123,6 @@ public enum BaseResponseStatus {
     TEAM_SIZE_MISMATCH(HttpStatus.BAD_REQUEST, false, 4503, "초대할 멤버 수가 팀 크기와 일치하지 않습니다."),
     DIFFERENT_GENDER_CANNOT_INVITE(HttpStatus.BAD_REQUEST, false, 4504, "다른 성별의 사용자는 초대할 수 없습니다."),
     TEAM_NOT_READY(HttpStatus.BAD_REQUEST, false, 4505, "모든 멤버가 수락해야 팀이 활성화됩니다."),
-    TEAM_ALREADY_MATCHED(HttpStatus.BAD_REQUEST, false, 4506, "매칭이 성사된 팀은 수정/삭제할 수 없습니다."),
 
     /**
      * 5000: 채팅방 관련 에러
@@ -144,18 +139,7 @@ public enum BaseResponseStatus {
     VOTE_NOT_AVAILABLE(HttpStatus.FORBIDDEN, false, 5010, "투표가 불가능합니다."),
     VOTE_OPTION_REQUIRED(HttpStatus.BAD_REQUEST, false, 5011, "옵션을 하나 이상 선택해야합니다."),
     VOTE_NOT_MULTIPLE(HttpStatus.BAD_REQUEST, false, 5012, "단일 투표에서 중복 투표는 불가능합니다."),
-    INVALID_VOTE_OPTION(HttpStatus.BAD_REQUEST, false, 5013, "해당 투표의 옵션ID가 아닙니다."),
-
-    /**
-     * 8000: SMTP(메일) 관련 에러
-     */
-    UNSUPPORTED_MAIL_TYPE(HttpStatus.BAD_REQUEST, false, 8000, "지원하지 않는 메일 타입입니다."),
-    MAIL_VERIFICATION_COOLDOWN(HttpStatus.TOO_MANY_REQUESTS, false, 8001, "인증코드 재요청이 너무 빠릅니다."),
-    MAIL_VERIFICATION_ATTEMPTS_EXCEEDED(HttpStatus.TOO_MANY_REQUESTS, false, 8002, "인증코드 입력 횟수를 초과했습니다."),
-    MAIL_VERIFICATION_MISMATCH(HttpStatus.BAD_REQUEST, false, 8003, "인증코드가 일치하지 않습니다."),
-    MAIL_VERIFICATION_EXPIRED(HttpStatus.BAD_REQUEST, false, 8004, "인증코드가 만료되었거나 존재하지 않습니다."),
-    MAIL_VERIFICATION_REQUIRED(HttpStatus.BAD_REQUEST, false, 8005, "이메일 인증이 필요합니다."),
-    MAIL_SEND_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, false, 8500, "메일 발송에 실패했습니다.");
+    INVALID_VOTE_OPTION(HttpStatus.BAD_REQUEST, false, 5013, "해당 투표의 옵션ID가 아닙니다.");
 
 
     private final HttpStatusCode httpStatusCode;

--- a/src/main/java/com/mini/buting/global/response/BaseResponseStatus.java
+++ b/src/main/java/com/mini/buting/global/response/BaseResponseStatus.java
@@ -151,6 +151,7 @@ public enum BaseResponseStatus {
      */
     READ_FILE_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, false, 6001, "파일을 읽는데 실패했습니다."),
     FAST_API_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, false, 6002, "AI 분석에 실패했습니다."),
+    UNSUPPORTED_FACE_SHAPE_TYPE(HttpStatus.BAD_REQUEST, false, 6400, "지원하지 않는 Face Shape 타입입니다."),
 
     /**
      * 8000: SMTP(메일) 관련 에러

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -88,3 +88,6 @@ rabbitmq:
 
 snowflake:
   node-id: ${SNOWFLAKE_NODE_ID}
+
+fastapi:
+  url: ${FASTAPI_URI}


### PR DESCRIPTION
### 🔗 Connected Pull Requests
#47 
#55 

### 📅 Development Period

2026.02.22 ~ 2026.02.22

### 📢 Description
#### (1) 배경
- #47 이후 develop 충돌 해결 과정에서 일부 의존성/응답코드 누락이 확인됨
- 해당 이슈로 #55 Revert가 진행
- 또한, AI 얼굴 분석 API의 경우 회원가입 전, 후 모두 호출 가능한 API이며, 호출 상황에 따라 Gender 수집, 후처리 동작(멤버 정보 업데이트)이 상이하나 기존 구현 API에 반영되어 있지 않았음. 

#### (2) 변경 및 신규
##### 1. jjwt 의존성 누락 복구
##### 2. BaseResponseStatus 누락 복구

##### 3. AI 얼굴 분석 API를 인증 상태에 따라 분리
- `POST /v1/ai` (비인증/회원가입용): `gender + file` 기반 분석
- `POST /v1/ai/me` (인증 전용): JWT 사용자 기준 분석 후 `member.faceShape` 업데이트
- `AiResponse` 식별자 필드 `id` → `faceShapeId`로 변경 (회원가입 요청과 정합성 확보)
- `FaceShapeRepository.findByName` 반환 타입 `Optional`로 변경

### ✔️ PR Checklist

MR이 아래 사항을 충족하는지 확인해주세요:

- [x] Merge 방향 및 Branch 확인했습니다.
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 코드가 정상적으로 동작하는지 테스트했습니다.

### 🔖 Note

- 현재 MySQL `face_shape` 데이터 일부 누락으로 FastAPI 응답값과 DB 매핑 불일치(6400)가 발생할 수 있습니다.
- 운영 DB에 `face_shape` 마스터 데이터 insert가 필요합니다. (@jangjongwon)